### PR TITLE
Fix for #5

### DIFF
--- a/src/collective/recipe/backup/main.py
+++ b/src/collective/recipe/backup/main.py
@@ -54,11 +54,11 @@ def snapshot_main(bin_dir, storages, keep, verbose, gzip,
         return
     for storage in storages:
         blobdir = storage['blobdir']
-        blob_snapshot_location = storage['blob_snapshot_location']
         if not blobdir:
             logger.info("No blob dir defined for %s storage" % \
                                                 (storage['storage']))
             continue
+        blob_snapshot_location = storage['blob_snapshot_location']
         logger.info("Please wait while making snapshot of blobs from %s to %s",
                     blobdir, blob_snapshot_location)
         copyblobs.backup_blobs(blobdir, blob_snapshot_location,


### PR DESCRIPTION
https://github.com/collective/collective.recipe.backup/issues/5

On a setup with multiple databases (in our setup we have 2) but only one blobstorage a snapshot backup breaks because one of the databases doesn't have a blobstorage defined.

This line change fixes it.
