### PR TITLE
Without explicit blob-storage option, default to var/blobstorage.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 4.0b2 (unreleased)
 ==================
 
+- Without explicit ``blob-storage`` option, default to ``var/blobstorage``.
+  Take the ``var`` option from zeoserver/client recipes into account.
+  Fixes `issue #27 <https://github.com/collective/collective.recipe.backup/issues/27>`_.
+  [maurits]
+
 - Do not create hidden backup ``.0`` when blob_storage ends with a slash.
   Fixes `issue #26 <https://github.com/collective/collective.recipe.backup/issues/26>`_.
   [maurits]

--- a/src/collective/recipe/backup/__init__.py
+++ b/src/collective/recipe/backup/__init__.py
@@ -178,8 +178,14 @@ class Recipe(object):
             # instance/zeoclient/zeoserver part, if it is available.
             blob_storage = get_zope_option(self.buildout, 'blob-storage')
             if not blob_storage:
-                # 'None' would give a TypeError when setting the option.
-                blob_storage = ''
+                # The recipes put it in var/blobstorage by default.
+                # But if there is no recipe, then we don't set this.
+                if get_zope_option(self.buildout, 'recipe'):
+                    blob_storage = os.path.abspath(
+                        os.path.join(var_dir, 'blobstorage'))
+                else:
+                    # 'None' would give a TypeError when setting the option.
+                    blob_storage = ''
             options['blob_storage'] = blob_storage
         # Validate again, which also makes sure the blob storage options are
         # the same, for good measure.

--- a/src/collective/recipe/backup/tests/blobs.rst
+++ b/src/collective/recipe/backup/tests/blobs.rst
@@ -103,6 +103,61 @@ speed things up a bit):
     ...storage...1...
     ...zip_location.../var/zipbackups...
 
+Without explicit blob-storage option, it defaults to ``blobstorage`` in the var directory, which might be somewhere else.
+
+    >>> write('buildout.cfg',
+    ... """
+    ... [buildout]
+    ... index = http://pypi.python.org/simple
+    ... # Avoid suddenly updating zc.buildout or other packages:
+    ... newest = false
+    ... parts = instance backup
+    ... versions = versions
+    ...
+    ... [versions]
+    ... # A slightly older version that does not rely on the Zope2 egg
+    ... plone.recipe.zope2instance = 3.9
+    ... mailinglogger = 3.3
+    ...
+    ... [instance]
+    ... recipe = plone.recipe.zope2instance
+    ... user = admin:admin
+    ... var = ${buildout:directory}/var/another/
+    ...
+    ... [backup]
+    ... recipe = collective.recipe.backup
+    ... """)
+    >>> print system('bin/buildout') # doctest:+ELLIPSIS
+    Uninstalling instance.
+    Installing instance.
+    Updating backup.
+    Generated script '/sample-buildout/bin/backup'.
+    Generated script '/sample-buildout/bin/fullbackup'.
+    Generated script '/sample-buildout/bin/snapshotbackup'.
+    Generated script '/sample-buildout/bin/restore'.
+    Generated script '/sample-buildout/bin/snapshotrestore'...
+    <BLANKLINE>
+    >>> ls('bin')
+    -  backup
+    -  buildout
+    -  fullbackup
+    -  instance
+    -  mkzopeinstance
+    -  repozo
+    -  restore
+    -  snapshotbackup
+    -  snapshotrestore
+    >>> cat('bin/backup')
+    #!...
+    ...blob_backup_location.../var/another/blobstoragebackups...
+    ...blob_snapshot_location.../var/another/blobstoragesnapshots...
+    ...blob_zip_location.../var/another/blobstoragezips...
+    ...blobdir.../var/another/blobstorage...
+    ...datafs.../var/another/filestorage/Data.fs...
+    ...snapshot_location.../var/another/snapshotbackups...
+    ...storage...1...
+    ...zip_location.../var/another/zipbackups...
+
 Nowadays it is strange to not have a blob storage, at least with Plone
 4 and higher.  So we bail out when this is the case.
 


### PR DESCRIPTION
Take the `var` option from zeoserver/client recipes into account.
Fixes issue #27.