### PR TITLE
Removed doctest ELLIPSIS from single lines.

### DIFF
--- a/src/collective/recipe/backup/tests/altrestore.rst
+++ b/src/collective/recipe/backup/tests/altrestore.rst
@@ -38,7 +38,7 @@ the ``alternative_restore_sources`` option::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/fullbackup'.
@@ -50,7 +50,7 @@ the ``alternative_restore_sources`` option::
 
 Call the script::
 
-    >>> print system('bin/altrestore', input='yes\n')  # doctest:+ELLIPSIS
+    >>> print system('bin/altrestore', input='yes\n')
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data
     <BLANKLINE>
     This will replace the filestorage:
@@ -75,7 +75,7 @@ add it to the alternative::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     While:
@@ -97,7 +97,7 @@ Add blobstorage to the alternative, but not the original::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data ${buildout:directory}/alt/blobs
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     While:
       Installing backup.
@@ -118,7 +118,7 @@ Add blobstorage to original and alternative::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data ${buildout:directory}/alt/blobs
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/fullbackup'.
@@ -133,7 +133,7 @@ Call the script::
     >>> ls('var')
     d  filestorage
     >>> remove('var', 'filestorage')
-    >>> print system('bin/altrestore', input='yes\n')  # doctest:+ELLIPSIS
+    >>> print system('bin/altrestore', input='yes\n')
     <BLANKLINE>
     This will replace the filestorage:
         /sample-buildout/var/filestorage/Data.fs
@@ -151,7 +151,7 @@ Create the necessary sample directories and call the script again::
     >>> mkdir('alt', 'blobs', 'blobstorage.0')
     >>> mkdir('alt', 'blobs', 'blobstorage.0', 'blobstorage')
     >>> write('alt', 'blobs', 'blobstorage.0', 'blobstorage', 'blobfile.txt', 'Hello blob.')
-    >>> print system('bin/altrestore', input='yes\n')  # doctest:+ELLIPSIS
+    >>> print system('bin/altrestore', input='yes\n')
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data
     <BLANKLINE>
     This will replace the filestorage:
@@ -176,7 +176,7 @@ normal restore script.  If the date is too early, the real repozo script would f
 saying 'No files in repository before <date>'.  Our mock repozo script would accept it,
 but we have added a check in the blob restore so we now fail as well.
 
-    >>> print system('bin/altrestore 2000-12-31-23-59', input='yes\n')  # doctest:+ELLIPSIS
+    >>> print system('bin/altrestore 2000-12-31-23-59', input='yes\n')
     <BLANKLINE>
     This will replace the filestorage:
         /sample-buildout/var/filestorage/Data.fs
@@ -190,7 +190,7 @@ but we have added a check in the blob restore so we now fail as well.
 
 So test is with a date in the future::
 
-    >>> print system('bin/altrestore 2100-12-31-23-59', input='yes\n')  # doctest:+ELLIPSIS
+    >>> print system('bin/altrestore 2100-12-31-23-59', input='yes\n')
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data -D 2100-12-31-23-59
     <BLANKLINE>
     This will replace the filestorage:
@@ -231,7 +231,7 @@ Test in combination with additional filestorage::
     >>> mkdir('alt', 'fooblobs', 'blobstorage-foo.0')
     >>> mkdir('alt', 'fooblobs', 'blobstorage-foo.0', 'blobstorage-foo')
     >>> write('alt', 'fooblobs', 'blobstorage-foo.0', 'blobstorage-foo', 'fooblobfile.txt', 'Hello fooblob.')
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -241,7 +241,7 @@ Test in combination with additional filestorage::
     Generated script '/sample-buildout/bin/snapshotrestore'.
     Generated script '/sample-buildout/bin/altrestore'.
     <BLANKLINE>
-    >>> print system('bin/altrestore', input='yes\n')  # doctest:+ELLIPSIS
+    >>> print system('bin/altrestore', input='yes\n')
     --recover -o /sample-buildout/var/filestorage/foo/foo.fs -r /sample-buildout/alt/foo
     --recover -o /sample-buildout/var/filestorage/bar/bar.fs -r /sample-buildout/alt/bar
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data
@@ -293,7 +293,7 @@ When archive_blob is true, we use it::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data ${buildout:directory}/alt/blobs
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -303,7 +303,7 @@ When archive_blob is true, we use it::
     Generated script '/sample-buildout/bin/snapshotrestore'.
     Generated script '/sample-buildout/bin/altrestore'.
     <BLANKLINE>
-    >>> print system('bin/backup')  # doctest:+ELLIPSIS
+    >>> print system('bin/backup')
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
     INFO: Created /sample-buildout/var/backups
     INFO: Created /sample-buildout/var/blobstoragebackups
@@ -314,7 +314,7 @@ When archive_blob is true, we use it::
     >>> remove('alt', 'blobs')
     >>> print system('mv var/backups alt/data')
     >>> print system('mv var/blobstoragebackups alt/blobs')
-    >>> print system('bin/altrestore', input='yes\n')  # doctest:+ELLIPSIS
+    >>> print system('bin/altrestore', input='yes\n')
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data
     <BLANKLINE>
     This will replace the filestorage:
@@ -354,7 +354,7 @@ different names for the scripts::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing secondbackup.
     Generated script '/sample-buildout/bin/secondbackup'.
@@ -390,7 +390,7 @@ Specifying ``1`` instead of ``Data`` is fine::
     ... alternative_restore_sources =
     ...     1 ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling firstbackup.
     Uninstalling secondbackup.
     Installing backup.
@@ -401,7 +401,7 @@ Specifying ``1`` instead of ``Data`` is fine::
     Generated script '/sample-buildout/bin/snapshotrestore'.
     Generated script '/sample-buildout/bin/altrestore'.
     <BLANKLINE>
-    >>> print system('bin/altrestore', input='yes\n')  # doctest:+ELLIPSIS
+    >>> print system('bin/altrestore', input='yes\n')
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data
     <BLANKLINE>
     This will replace the filestorage:
@@ -425,7 +425,7 @@ Specifying both ``1`` and ``Data`` is bad::
     ...     1 ${buildout:directory}/alt/one
     ...     Data ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     While:
@@ -447,7 +447,7 @@ Switching them around also fails::
     ...     Data ${buildout:directory}/alt/data
     ...     1 ${buildout:directory}/alt/one
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     While:
       Installing backup.
@@ -469,7 +469,7 @@ Missing keys is bad::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     While:
       Installing backup.
@@ -488,7 +488,7 @@ Missing keys is bad::
     ... alternative_restore_sources =
     ...     foo ${buildout:directory}/alt/foo
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     While:
       Installing backup.
@@ -508,7 +508,7 @@ Extra keys are also bad::
     ... alternative_restore_sources =
     ...     foo ${buildout:directory}/alt/foo
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     While:
       Installing backup.
@@ -528,7 +528,7 @@ A filestorage source path is required::
     ... alternative_restore_sources =
     ...     Data
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     While:
       Installing backup.

--- a/src/collective/recipe/backup/tests/base.rst
+++ b/src/collective/recipe/backup/tests/base.rst
@@ -24,7 +24,7 @@ Running the buildout adds a backup, snapshotbackup, restore and
 snapshotrestore scripts to the ``bin/`` directory and, by default, it
 creates the ``var/backups`` and ``var/snapshotbackups`` dirs::
 
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/fullbackup'.
@@ -154,7 +154,7 @@ something else,  the script names will also be different as will the created
     ... recipe = collective.recipe.backup
     ... backup_blobs = false
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing plonebackup.
     Generated script '/sample-buildout/bin/plonebackup'.

--- a/src/collective/recipe/backup/tests/blob_timestamps.rst
+++ b/src/collective/recipe/backup/tests/blob_timestamps.rst
@@ -39,7 +39,7 @@ Write a buildout config::
     ...    foo ${buildout:directory}/var/filestorage/foo.fs ${buildout:directory}/var/blobstorage-foo
     ...    bar ${buildout:directory}/var/filestorage/bar.fs ${buildout:directory}/var/blobstorage-bar
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/fullbackup'.

--- a/src/collective/recipe/backup/tests/blobs.rst
+++ b/src/collective/recipe/backup/tests/blobs.rst
@@ -67,7 +67,7 @@ We run the buildout (and set a timeout as we need a few new packages
 and apparently a few servers are currently down so a timeout helps
 speed things up a bit):
 
-    >>> print system('bin/buildout -t 5') # doctest:+ELLIPSIS
+    >>> print system('bin/buildout -t 5')
     Setting socket time out to 5 seconds.
     Getting distribution for 'plone.recipe.zope2INSTANCE==3.9'...
     Got plone.recipe.zope2instance 3.9.
@@ -127,7 +127,7 @@ Without explicit blob-storage option, it defaults to ``blobstorage`` in the var 
     ... [backup]
     ... recipe = collective.recipe.backup
     ... """)
-    >>> print system('bin/buildout') # doctest:+ELLIPSIS
+    >>> print system('bin/buildout')
     Uninstalling instance.
     Installing instance.
     Updating backup.
@@ -178,7 +178,7 @@ is only for Plone 4 and higher.
     ... [backup]
     ... recipe = collective.recipe.backup
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling instance.
     Updating backup.
     While:
@@ -194,7 +194,7 @@ is only for Plone 4 and higher.
     ... recipe = collective.recipe.backup
     ... backup_blobs = false
     ... """)
-    >>> print system(buildout)  # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/fullbackup'.
@@ -217,7 +217,7 @@ We can override the additional_filestorages location:
     ... additional_filestorages =
     ...    catalog ${buildout:directory}/var/filestorage/2.fs
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -244,7 +244,7 @@ We can override the additional_filestorages blob source location:
     ...    withblob    ${buildout:directory}/var/filestorage/2.fs ${buildout:directory}/var/blobstorage2
     ...    withoutblob ${buildout:directory}/var/filestorage/3.fs
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -268,7 +268,7 @@ Wrong configurations for additional_filestorages:
     ... additional_filestorages =
     ...    wrong ${buildout:directory}/var/filestorage foo.fs ${buildout:directory}/var/blobstorage_foo
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     While:
@@ -293,7 +293,7 @@ Full cycle tests:
     ...    foo ${buildout:directory}/var/filestorage/foo.fs ${buildout:directory}/var/blobstorage-foo
     ...    bar ${buildout:directory}/var/filestorage/bar.fs ${buildout:directory}/var/blobstorage-bar/
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/fullbackup'.
@@ -804,7 +804,7 @@ blob_storage option, otherwise buildout quits::
     ... recipe = collective.recipe.backup
     ... backup_blobs = true
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     While:
@@ -826,7 +826,7 @@ Combining blob_backup=false and only_blobs=true will not work::
     ... backup_blobs = false
     ... only_blobs = true
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     While:
       Installing.
       Getting section backup.
@@ -855,7 +855,7 @@ enable_zipbackup too::
     ... only_blobs = true
     ... enable_zipbackup = true
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing filebackup.
     Generated script '/sample-buildout/bin/filebackup'.
     Generated script '/sample-buildout/bin/filebackup-full'.
@@ -959,7 +959,7 @@ restore to ensure passing of extra options to rsync works::
     ... blob_storage = ${buildout:directory}/var/blobstorage
     ... rsync_options = --no-l -k
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling blobbackup.
     Uninstalling filebackup.
     Installing backup.
@@ -1016,7 +1016,7 @@ So backup still works, now test restore that uses a symlinked directory as the b
     ... pre_command = ln -s ${buildout:directory}/var/blobstoragebackups/blobstorage.0/blobstorage ${backup:blobbackuplocation}/blobstorage.0/blobstorage
     ... post_command = unlink ${backup:blobbackuplocation}/blobstorage.0/blobstorage
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -1059,7 +1059,7 @@ See issue #26. So test what happens:
     ... recipe = collective.recipe.backup
     ... blob_storage = ${buildout:directory}/var/blobstorage/
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.

--- a/src/collective/recipe/backup/tests/location.rst
+++ b/src/collective/recipe/backup/tests/location.rst
@@ -94,7 +94,7 @@ We'll use all options, except the blob options for now::
     ... backup_blobs = false
     ... location = /my/unusable/path/for/backup
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     utils: WARNING: Not able to create /my/unusable/path/for/backup

--- a/src/collective/recipe/backup/tests/multiple.rst
+++ b/src/collective/recipe/backup/tests/multiple.rst
@@ -42,7 +42,7 @@ The additional backups have to be stored separate from the ``Data.fs``
 backup. That's done by appending the file's name and creating extra backup
 directories named that way::
 
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/fullbackup'.

--- a/src/collective/recipe/backup/tests/no_rsync.rst
+++ b/src/collective/recipe/backup/tests/no_rsync.rst
@@ -38,7 +38,7 @@ First we create some fresh content:
 One thing we test here is if the buildout does not create too many
 directories that will not get used because have set only_blobs=true::
 
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/fullbackup'.

--- a/src/collective/recipe/backup/tests/options.rst
+++ b/src/collective/recipe/backup/tests/options.rst
@@ -38,7 +38,7 @@ We'll use most options, except the blob options for now::
     ...     echo 'Thanks a lot for the backup.'
     ...     echo 'We are done.'
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/fullbackup'.
@@ -144,7 +144,7 @@ generated script).
     ... enable_snapshotrestore = false
     ... """)
 
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -182,7 +182,7 @@ wanted.
     ... quick = false
     ... """)
 
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -217,7 +217,7 @@ actually remove the previously generated script).
     ... enable_fullbackup = false
     ... """)
 
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.

--- a/src/collective/recipe/backup/tests/prefix.rst
+++ b/src/collective/recipe/backup/tests/prefix.rst
@@ -309,7 +309,7 @@ something else,  the script names will also be different as will the created
     ... backup_blobs = false
     ... locationprefix = ${buildout:directory}/backuplocation
     ... """)
-    >>> print system(buildout) # doctest:+ELLIPSIS
+    >>> print system(buildout)
     Uninstalling backup.
     Installing plonebackup.
     Generated script '/sample-buildout/bin/plonebackup'.
@@ -355,4 +355,4 @@ the ``backuplocation/plonebackups`` and ``backuplocation/plonebackup-snaphots`` 
     ... backup_blobs = false
     ... locationprefix = ${buildout:directory}/backuplocation
     ... """)
-    >>> dont_care = system(buildout) # doctest:+ELLIPSIS
+    >>> dont_care = system(buildout)


### PR DESCRIPTION
This is already global in `tests/test_docs.py`. In individual lines it is being cargo culted along needlessly.