### PR TITLE
No longer create the fullbackup script by default.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 4.0b2 (unreleased)
 ==================
 
+- No longer create the ``fullbackup`` script by default.
+  You can still enable it by setting ``enable_fullbackup`` to ``true``.
+  [maurits]
+
 - Without explicit ``blob-storage`` option, default to ``var/blobstorage``.
   Take the ``var`` option from zeoserver/client recipes into account.
   Fixes `issue #27 <https://github.com/collective/collective.recipe.backup/issues/27>`_.

--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,8 @@ cake is important!
 - ``bin/backup`` makes an incremental backup.
 
 - ``bin/fullbackup`` always makes a full backup, in the same directory
-  as the normal backups.  You can disable this by setting the
-  ``enable_fullbackup`` option to false.
+  as the normal backups.  You can enable this by setting the
+  ``enable_fullbackup`` option to true.
 
 - ``bin/restore`` restores the latest backup, created by the backup or
   fullbackup script.
@@ -171,6 +171,9 @@ have a blob storage it is by default backed up to
 set different cron jobs for full and incremental backups.  You may
 want to have incrementals done daily, with full backups done weekly.
 Now you can!
+
+Since version 4.0, the fullbackup script is not created by default.
+Enable it by setting ``enable_fullbackup`` to ``true``
 
 You should normally do a ``bin/zeopack`` regularly, say once a week,
 to remove unused objects from your Zope ``Data.fs``.  The next time
@@ -383,7 +386,7 @@ some system-wide directory like ``/var/zopebackups/instancename/`` and
     with ``--verbose`` if this option is enabled.
 
 ``enable_fullbackup``
-    Create ``fullbackup`` script.  Default: true.
+    Create ``fullbackup`` script.  Default: false (changed in 4.0).
 
 ``enable_snapshotrestore``
     Having a ``snapshotrestore`` script is very useful in development

--- a/src/collective/recipe/backup/__init__.py
+++ b/src/collective/recipe/backup/__init__.py
@@ -157,7 +157,7 @@ class Recipe(object):
         options.setdefault('compress_blob', 'false')
         options.setdefault('datafs', datafs)
         options.setdefault('debug', 'false')
-        options.setdefault('enable_fullbackup', 'true')
+        options.setdefault('enable_fullbackup', 'false')
         options.setdefault('enable_snapshotrestore', 'true')
         options.setdefault('enable_zipbackup', 'false')
         options.setdefault('full', 'false')

--- a/src/collective/recipe/backup/tests/altrestore.rst
+++ b/src/collective/recipe/backup/tests/altrestore.rst
@@ -41,7 +41,6 @@ the ``alternative_restore_sources`` option::
     >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -121,7 +120,6 @@ Add blobstorage to original and alternative::
     >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -235,7 +233,6 @@ Test in combination with additional filestorage::
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -297,7 +294,6 @@ When archive_blob is true, we use it::
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -358,14 +354,12 @@ different names for the scripts::
     Uninstalling backup.
     Installing secondbackup.
     Generated script '/sample-buildout/bin/secondbackup'.
-    Generated script '/sample-buildout/bin/secondbackup-full'.
     Generated script '/sample-buildout/bin/secondbackup-snapshot'.
     Generated script '/sample-buildout/bin/secondbackup-restore'.
     Generated script '/sample-buildout/bin/secondbackup-snapshotrestore'.
     Generated script '/sample-buildout/bin/secondbackup-altrestore'.
     Installing firstbackup.
     Generated script '/sample-buildout/bin/firstbackup'.
-    Generated script '/sample-buildout/bin/firstbackup-full'.
     Generated script '/sample-buildout/bin/firstbackup-snapshot'.
     Generated script '/sample-buildout/bin/firstbackup-restore'.
     Generated script '/sample-buildout/bin/firstbackup-snapshotrestore'.
@@ -395,7 +389,6 @@ Specifying ``1`` instead of ``Data`` is fine::
     Uninstalling secondbackup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.

--- a/src/collective/recipe/backup/tests/base.rst
+++ b/src/collective/recipe/backup/tests/base.rst
@@ -18,6 +18,7 @@ The simplest way to use it is to add a part in ``buildout.cfg`` like this::
     ... [backup]
     ... recipe = collective.recipe.backup
     ... backup_blobs = false
+    ... enable_fullbackup = true
     ... """)
 
 Running the buildout adds a backup, snapshotbackup, restore and
@@ -158,7 +159,6 @@ something else,  the script names will also be different as will the created
     Uninstalling backup.
     Installing plonebackup.
     Generated script '/sample-buildout/bin/plonebackup'.
-    Generated script '/sample-buildout/bin/plonebackup-full'.
     Generated script '/sample-buildout/bin/plonebackup-snapshot'.
     Generated script '/sample-buildout/bin/plonebackup-restore'.
     Generated script '/sample-buildout/bin/plonebackup-snapshotrestore'.
@@ -170,7 +170,6 @@ name is ``[backup]`` is now prefixed with the part name:
     >>> ls('bin')
     -  buildout
     -  plonebackup
-    -  plonebackup-full
     -  plonebackup-restore
     -  plonebackup-snapshot
     -  plonebackup-snapshotrestore

--- a/src/collective/recipe/backup/tests/blob_timestamps.rst
+++ b/src/collective/recipe/backup/tests/blob_timestamps.rst
@@ -42,7 +42,6 @@ Write a buildout config::
     >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -50,7 +49,6 @@ Write a buildout config::
     >>> ls('bin')
     -  backup
     -  buildout
-    -  fullbackup
     -  repozo
     -  restore
     -  snapshotbackup
@@ -564,7 +562,6 @@ Create some archived (gzipped) and not-archived separate backup scripts::
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/zipbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.

--- a/src/collective/recipe/backup/tests/blobs.rst
+++ b/src/collective/recipe/backup/tests/blobs.rst
@@ -77,7 +77,6 @@ speed things up a bit):
     Generated script '/sample-buildout/bin/instance'.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'...
@@ -85,7 +84,6 @@ speed things up a bit):
     >>> ls('bin')
     -  backup
     -  buildout
-    -  fullbackup
     -  instance
     -  mkzopeinstance
     -  repozo
@@ -132,7 +130,6 @@ Without explicit blob-storage option, it defaults to ``blobstorage`` in the var 
     Installing instance.
     Updating backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'...
@@ -140,7 +137,6 @@ Without explicit blob-storage option, it defaults to ``blobstorage`` in the var 
     >>> ls('bin')
     -  backup
     -  buildout
-    -  fullbackup
     -  instance
     -  mkzopeinstance
     -  repozo
@@ -197,7 +193,6 @@ is only for Plone 4 and higher.
     >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -221,7 +216,6 @@ We can override the additional_filestorages location:
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -248,7 +242,6 @@ We can override the additional_filestorages blob source location:
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -296,7 +289,6 @@ Full cycle tests:
     >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -304,7 +296,6 @@ Full cycle tests:
     >>> ls('bin')
     -  backup
     -  buildout
-    -  fullbackup
     -  instance
     -  mkzopeinstance
     -  repozo
@@ -858,13 +849,11 @@ enable_zipbackup too::
     >>> print system(buildout)
     Installing filebackup.
     Generated script '/sample-buildout/bin/filebackup'.
-    Generated script '/sample-buildout/bin/filebackup-full'.
     Generated script '/sample-buildout/bin/filebackup-snapshot'.
     Generated script '/sample-buildout/bin/filebackup-restore'.
     Generated script '/sample-buildout/bin/filebackup-snapshotrestore'.
     Installing blobbackup.
     Generated script '/sample-buildout/bin/blobbackup'.
-    Generated script '/sample-buildout/bin/blobbackup-full'.
     Generated script '/sample-buildout/bin/blobbackup-zip'.
     Generated script '/sample-buildout/bin/blobbackup-snapshot'.
     Generated script '/sample-buildout/bin/blobbackup-restore'.
@@ -964,7 +953,6 @@ restore to ensure passing of extra options to rsync works::
     Uninstalling filebackup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -972,7 +960,6 @@ restore to ensure passing of extra options to rsync works::
     >>> ls('bin')
     - backup
     - buildout
-    - fullbackup
     - instance
     - mkzopeinstance
     - repozo
@@ -1020,7 +1007,6 @@ So backup still works, now test restore that uses a symlinked directory as the b
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -1028,7 +1014,6 @@ So backup still works, now test restore that uses a symlinked directory as the b
     >>> ls('bin')
     - backup
     - buildout
-    - fullbackup
     - instance
     - mkzopeinstance
     - repozo
@@ -1063,7 +1048,6 @@ See issue #26. So test what happens:
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.

--- a/src/collective/recipe/backup/tests/gzip.rst
+++ b/src/collective/recipe/backup/tests/gzip.rst
@@ -53,19 +53,16 @@ Create some archived (gzipped) and not-archived separate backup scripts::
     >>> print system(buildout)
     Installing nozipbackup.
     Generated script '/sample-buildout/bin/nozipbackup'.
-    Generated script '/sample-buildout/bin/nozipbackup-full'.
     Generated script '/sample-buildout/bin/nozipbackup-snapshot'.
     Generated script '/sample-buildout/bin/nozipbackup-restore'.
     Generated script '/sample-buildout/bin/nozipbackup-snapshotrestore'.
     Installing zippedbackup.
     Generated script '/sample-buildout/bin/zippedbackup'.
-    Generated script '/sample-buildout/bin/zippedbackup-full'.
     Generated script '/sample-buildout/bin/zippedbackup-snapshot'.
     Generated script '/sample-buildout/bin/zippedbackup-restore'.
     Generated script '/sample-buildout/bin/zippedbackup-snapshotrestore'.
     Installing compressedbackup.
     Generated script '/sample-buildout/bin/compressedbackup'.
-    Generated script '/sample-buildout/bin/compressedbackup-full'.
     Generated script '/sample-buildout/bin/compressedbackup-snapshot'.
     Generated script '/sample-buildout/bin/compressedbackup-restore'.
     Generated script '/sample-buildout/bin/compressedbackup-snapshotrestore'.

--- a/src/collective/recipe/backup/tests/location.rst
+++ b/src/collective/recipe/backup/tests/location.rst
@@ -66,7 +66,6 @@ is probably grudgingly allowed, at least by this particular check.
     >>> print system('bin/buildout')
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/zipbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
@@ -99,7 +98,6 @@ We'll use all options, except the blob options for now::
     Installing backup.
     utils: WARNING: Not able to create /my/unusable/path/for/backup
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.

--- a/src/collective/recipe/backup/tests/multiple.rst
+++ b/src/collective/recipe/backup/tests/multiple.rst
@@ -45,7 +45,6 @@ directories named that way::
     >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.

--- a/src/collective/recipe/backup/tests/no_rsync.rst
+++ b/src/collective/recipe/backup/tests/no_rsync.rst
@@ -41,7 +41,6 @@ directories that will not get used because have set only_blobs=true::
     >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.

--- a/src/collective/recipe/backup/tests/options.rst
+++ b/src/collective/recipe/backup/tests/options.rst
@@ -41,7 +41,6 @@ We'll use most options, except the blob options for now::
     >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -148,14 +147,12 @@ generated script).
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     <BLANKLINE>
     >>> ls('bin')
     -  backup
     -  buildout
-    -  fullbackup
     -  repozo
     -  restore
     -  snapshotbackup
@@ -186,7 +183,6 @@ wanted.
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -198,12 +194,12 @@ wanted.
     <BLANKLINE>
 
 
-Disable the fullbackup script
------------------------------
+Enable the fullbackup script
+----------------------------
 
-We generate a new buildout with enable_fullbackup set to false.  The
-fullbackup script should not be generated now (and buildout will
-actually remove the previously generated script).
+We generate a new buildout with enable_fullbackup set to true.
+This actually was the default before 4.0.
+The fullbackup script should be generated now.
 
     >>> write('buildout.cfg',
     ... """
@@ -214,13 +210,14 @@ actually remove the previously generated script).
     ... [backup]
     ... recipe = collective.recipe.backup
     ... backup_blobs = false
-    ... enable_fullbackup = false
+    ... enable_fullbackup = true
     ... """)
 
     >>> print system(buildout)
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
+    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -228,6 +225,7 @@ actually remove the previously generated script).
     >>> ls('bin')
     -  backup
     -  buildout
+    -  fullbackup
     -  repozo
     -  restore
     -  snapshotbackup

--- a/src/collective/recipe/backup/tests/prefix.rst
+++ b/src/collective/recipe/backup/tests/prefix.rst
@@ -21,6 +21,7 @@ The simplest way to use it is to add a part in ``buildout.cfg`` like this::
     ... recipe = collective.recipe.backup
     ... backup_blobs = false
     ... locationprefix = ${buildout:directory}/backuplocation
+    ... enable_fullbackup = true
     ... """)
 
 Let's run the buildout::
@@ -161,7 +162,6 @@ Let's run the buildout::
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/zipbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
@@ -183,13 +183,6 @@ And run the scripts::
     d  blobstorage
     >>> ls('backuplocation', 'std', 'blobs', 'blobstorage.0', 'blobstorage')
     -  blob.txt
-    >>> print system('bin/fullbackup')
-    --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/std/datafs -F --gzip
-    INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/backuplocation/std/datafs
-    INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/backuplocation/std/blobs
-    INFO: Renaming blobstorage.0 to blobstorage.1.
-    INFO: rsync -a  --delete --link-dest=../blobstorage.1 /sample-buildout/var/blobstorage /sample-buildout/backuplocation/std/blobs/blobstorage.0
-    <BLANKLINE>
     >>> print system('bin/zipbackup')
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/snapshots/zip -F --gzip
     INFO: Created /sample-buildout/backuplocation/snapshots/zip
@@ -272,7 +265,6 @@ Let's run the buildout::
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -308,6 +300,7 @@ something else,  the script names will also be different as will the created
     ... recipe = collective.recipe.backup
     ... backup_blobs = false
     ... locationprefix = ${buildout:directory}/backuplocation
+    ... enable_fullbackup = true
     ... """)
     >>> print system(buildout)
     Uninstalling backup.
@@ -340,19 +333,3 @@ The different part name *did* result in two directories named after the part:
     d  snapshotbackups
     d  snapshots
     d  std
-
-For the rest of the tests we use the ``[backup]`` name again.  And we clean up
-the ``backuplocation/plonebackups`` and ``backuplocation/plonebackup-snaphots`` dirs:
-
-    >>> write('buildout.cfg',
-    ... """
-    ... [buildout]
-    ... newest = false
-    ... parts = backup
-    ...
-    ... [backup]
-    ... recipe = collective.recipe.backup
-    ... backup_blobs = false
-    ... locationprefix = ${buildout:directory}/backuplocation
-    ... """)
-    >>> dont_care = system(buildout)

--- a/src/collective/recipe/backup/tests/zipbackup.rst
+++ b/src/collective/recipe/backup/tests/zipbackup.rst
@@ -48,7 +48,6 @@ Create some archived (gzipped) and not-archived separate backup scripts::
     >>> print system(buildout)
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/zipbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
@@ -114,7 +113,6 @@ You can choose not to enable the zip scripts::
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
@@ -122,7 +120,6 @@ You can choose not to enable the zip scripts::
     >>> ls('bin')
     -  backup
     -  buildout
-    -  fullbackup
     -  repozo
     -  restore
     -  snapshotbackup
@@ -146,14 +143,12 @@ the default::
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
-    Generated script '/sample-buildout/bin/fullbackup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
     >>> ls('bin')
     -  backup
     -  buildout
-    -  fullbackup
     -  repozo
     -  restore
     -  snapshotbackup


### PR DESCRIPTION
You can still enable it by setting `enable_fullbackup` to `true`.

Fixes issue #28.