### PR TITLE
Python 3 basic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
 4.0b3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Added basic Python 3 support.  We do not test with it yet,
+  but you should not get NameErrors anymore.
+  See `issue #31 <https://github.com/collective/collective.recipe.backup/issues/31>`_. [maurits]
 
 
 4.0b2 (2017-06-26)

--- a/src/collective/recipe/backup/__init__.py
+++ b/src/collective/recipe/backup/__init__.py
@@ -589,7 +589,7 @@ def check_for_true(options, keys):
 def to_bool(option):
     if option is None:
         return False
-    if not isinstance(option, basestring):
+    if not isinstance(option, utils.stringtypes):
         return bool(option)
     option = option.lower()
     return option in ('true', 'yes', 'on', '1')

--- a/src/collective/recipe/backup/copyblobs.py
+++ b/src/collective/recipe/backup/copyblobs.py
@@ -25,6 +25,12 @@ BACKUP_DIR = 'backups'
 is_time_stamp = re.compile(r'\d{4}(?:-\d\d){5}$').match
 
 
+# cmp is not available on Python 3, so use an alternative.
+# See http://python-future.org/compatible_idioms.html#cmp
+def cmp(x, y):
+    return (x > y) - (x < y)
+
+
 def get_prefix_and_number(value, prefix=None, suffixes=None):
     """Get prefix and number out of value.
 
@@ -46,7 +52,7 @@ def get_prefix_and_number(value, prefix=None, suffixes=None):
     but it would be hard to read.
     """
     if suffixes is not None:
-        if isinstance(suffixes, basestring):
+        if isinstance(suffixes, utils.stringtypes):
             suffixes = [suffixes]
         found = False
         for suffix in suffixes:

--- a/src/collective/recipe/backup/tests/altrestore.rst
+++ b/src/collective/recipe/backup/tests/altrestore.rst
@@ -11,7 +11,7 @@ Add mock ``bin/repozo`` script::
 
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 Create directories::
@@ -38,7 +38,7 @@ the ``alternative_restore_sources`` option::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
@@ -49,7 +49,7 @@ the ``alternative_restore_sources`` option::
 
 Call the script::
 
-    >>> print system('bin/altrestore', input='yes\n')
+    >>> print(system('bin/altrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data
     <BLANKLINE>
     This will replace the filestorage:
@@ -74,7 +74,7 @@ add it to the alternative::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     While:
@@ -96,7 +96,7 @@ Add blobstorage to the alternative, but not the original::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data ${buildout:directory}/alt/blobs
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     While:
       Installing backup.
@@ -117,7 +117,7 @@ Add blobstorage to original and alternative::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data ${buildout:directory}/alt/blobs
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
@@ -131,7 +131,7 @@ Call the script::
     >>> ls('var')
     d  filestorage
     >>> remove('var', 'filestorage')
-    >>> print system('bin/altrestore', input='yes\n')
+    >>> print(system('bin/altrestore', input='yes\n'))
     <BLANKLINE>
     This will replace the filestorage:
         /sample-buildout/var/filestorage/Data.fs
@@ -149,7 +149,7 @@ Create the necessary sample directories and call the script again::
     >>> mkdir('alt', 'blobs', 'blobstorage.0')
     >>> mkdir('alt', 'blobs', 'blobstorage.0', 'blobstorage')
     >>> write('alt', 'blobs', 'blobstorage.0', 'blobstorage', 'blobfile.txt', 'Hello blob.')
-    >>> print system('bin/altrestore', input='yes\n')
+    >>> print(system('bin/altrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data
     <BLANKLINE>
     This will replace the filestorage:
@@ -174,7 +174,7 @@ normal restore script.  If the date is too early, the real repozo script would f
 saying 'No files in repository before <date>'.  Our mock repozo script would accept it,
 but we have added a check in the blob restore so we now fail as well.
 
-    >>> print system('bin/altrestore 2000-12-31-23-59', input='yes\n')
+    >>> print(system('bin/altrestore 2000-12-31-23-59', input='yes\n'))
     <BLANKLINE>
     This will replace the filestorage:
         /sample-buildout/var/filestorage/Data.fs
@@ -188,7 +188,7 @@ but we have added a check in the blob restore so we now fail as well.
 
 So test is with a date in the future::
 
-    >>> print system('bin/altrestore 2100-12-31-23-59', input='yes\n')
+    >>> print(system('bin/altrestore 2100-12-31-23-59', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data -D 2100-12-31-23-59
     <BLANKLINE>
     This will replace the filestorage:
@@ -229,7 +229,7 @@ Test in combination with additional filestorage::
     >>> mkdir('alt', 'fooblobs', 'blobstorage-foo.0')
     >>> mkdir('alt', 'fooblobs', 'blobstorage-foo.0', 'blobstorage-foo')
     >>> write('alt', 'fooblobs', 'blobstorage-foo.0', 'blobstorage-foo', 'fooblobfile.txt', 'Hello fooblob.')
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -238,7 +238,7 @@ Test in combination with additional filestorage::
     Generated script '/sample-buildout/bin/snapshotrestore'.
     Generated script '/sample-buildout/bin/altrestore'.
     <BLANKLINE>
-    >>> print system('bin/altrestore', input='yes\n')
+    >>> print(system('bin/altrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/foo/foo.fs -r /sample-buildout/alt/foo
     --recover -o /sample-buildout/var/filestorage/bar/bar.fs -r /sample-buildout/alt/bar
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data
@@ -290,7 +290,7 @@ When archive_blob is true, we use it::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data ${buildout:directory}/alt/blobs
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -299,7 +299,7 @@ When archive_blob is true, we use it::
     Generated script '/sample-buildout/bin/snapshotrestore'.
     Generated script '/sample-buildout/bin/altrestore'.
     <BLANKLINE>
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
     INFO: Created /sample-buildout/var/backups
     INFO: Created /sample-buildout/var/blobstoragebackups
@@ -308,9 +308,9 @@ When archive_blob is true, we use it::
     INFO: tar cf /sample-buildout/var/blobstoragebackups/blobstorage.0.tar -C /sample-buildout/var/blobstorage .
     >>> remove('alt', 'data')
     >>> remove('alt', 'blobs')
-    >>> print system('mv var/backups alt/data')
-    >>> print system('mv var/blobstoragebackups alt/blobs')
-    >>> print system('bin/altrestore', input='yes\n')
+    >>> print(system('mv var/backups alt/data'))
+    >>> print(system('mv var/blobstoragebackups alt/blobs'))
+    >>> print(system('bin/altrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data
     <BLANKLINE>
     This will replace the filestorage:
@@ -350,7 +350,7 @@ different names for the scripts::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing secondbackup.
     Generated script '/sample-buildout/bin/secondbackup'.
@@ -384,7 +384,7 @@ Specifying ``1`` instead of ``Data`` is fine::
     ... alternative_restore_sources =
     ...     1 ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling firstbackup.
     Uninstalling secondbackup.
     Installing backup.
@@ -394,7 +394,7 @@ Specifying ``1`` instead of ``Data`` is fine::
     Generated script '/sample-buildout/bin/snapshotrestore'.
     Generated script '/sample-buildout/bin/altrestore'.
     <BLANKLINE>
-    >>> print system('bin/altrestore', input='yes\n')
+    >>> print(system('bin/altrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/alt/data
     <BLANKLINE>
     This will replace the filestorage:
@@ -418,7 +418,7 @@ Specifying both ``1`` and ``Data`` is bad::
     ...     1 ${buildout:directory}/alt/one
     ...     Data ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     While:
@@ -440,7 +440,7 @@ Switching them around also fails::
     ...     Data ${buildout:directory}/alt/data
     ...     1 ${buildout:directory}/alt/one
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     While:
       Installing backup.
@@ -462,7 +462,7 @@ Missing keys is bad::
     ... alternative_restore_sources =
     ...     Data ${buildout:directory}/alt/data
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     While:
       Installing backup.
@@ -481,7 +481,7 @@ Missing keys is bad::
     ... alternative_restore_sources =
     ...     foo ${buildout:directory}/alt/foo
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     While:
       Installing backup.
@@ -501,7 +501,7 @@ Extra keys are also bad::
     ... alternative_restore_sources =
     ...     foo ${buildout:directory}/alt/foo
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     While:
       Installing backup.
@@ -521,7 +521,7 @@ A filestorage source path is required::
     ... alternative_restore_sources =
     ...     Data
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     While:
       Installing backup.

--- a/src/collective/recipe/backup/tests/base.rst
+++ b/src/collective/recipe/backup/tests/base.rst
@@ -25,7 +25,7 @@ Running the buildout adds a backup, snapshotbackup, restore and
 snapshotrestore scripts to the ``bin/`` directory and, by default, it
 creates the ``var/backups`` and ``var/snapshotbackups`` dirs::
 
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/fullbackup'.
@@ -52,12 +52,12 @@ Some needed imports:
 
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 By default, backups are done in ``var/backups``::
 
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
     INFO: Created /sample-buildout/var/backups
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/backups
@@ -65,7 +65,7 @@ By default, backups are done in ``var/backups``::
 
 Full backups are placed there too::
 
-    >>> print system('bin/fullbackup')
+    >>> print(system('bin/fullbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups -F --gzip
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/backups
     <BLANKLINE>
@@ -79,7 +79,7 @@ This will create the target directory when it does not exist::
 
     >>> ls('var')
     d  backups
-    >>> print system('bin/restore', input='yes\n')
+    >>> print(system('bin/restore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups
     <BLANKLINE>
     This will replace the filestorage:
@@ -97,7 +97,7 @@ You can also restore the backup as of a certain date. Just pass a date
 argument. According to repozo: specify UTC (not local) time.  The format is
 ``yyyy-mm-dd[-hh[-mm[-ss]]]``.
 
-    >>> print system('bin/restore 1972-12-25', input='yes\n')
+    >>> print(system('bin/restore 1972-12-25', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups -D 1972-12-25
     <BLANKLINE>
     This will replace the filestorage:
@@ -120,7 +120,7 @@ backup just before updating the production server is a good idea. For that,
 the ``bin/snapshotbackup`` is great. It places a full backup in, by default,
 ``var/snapshotbackups``.
 
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
     INFO: Created /sample-buildout/var/snapshotbackups
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/snapshotbackups
@@ -128,7 +128,7 @@ the ``bin/snapshotbackup`` is great. It places a full backup in, by default,
 
 You can restore the very latest snapshotbackup with ``bin/snapshotrestore``::
 
-    >>> print system('bin/snapshotrestore', input='yes\n')
+    >>> print(system('bin/snapshotrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups
     <BLANKLINE>
     This will replace the filestorage:
@@ -155,7 +155,7 @@ something else,  the script names will also be different as will the created
     ... recipe = collective.recipe.backup
     ... backup_blobs = false
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing plonebackup.
     Generated script '/sample-buildout/bin/plonebackup'.

--- a/src/collective/recipe/backup/tests/blob_timestamps.rst
+++ b/src/collective/recipe/backup/tests/blob_timestamps.rst
@@ -16,7 +16,7 @@ Add mock ``bin/repozo`` script::
     >>> import os
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 Write a buildout config::
@@ -39,7 +39,7 @@ Write a buildout config::
     ...    foo ${buildout:directory}/var/filestorage/foo.fs ${buildout:directory}/var/blobstorage-foo
     ...    bar ${buildout:directory}/var/filestorage/bar.fs ${buildout:directory}/var/blobstorage-bar
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
@@ -64,7 +64,7 @@ Write a buildout config::
 
 Test the snapshotbackup first, as that should be easiest.
 
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -F --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -F --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
@@ -108,7 +108,7 @@ Note that due to the timestamps no renaming takes place from blobstorage.0 to bl
     >>> write('var', 'blobstorage', 'blob2.txt', "Sample blob 2.")
     >>> write('var', 'blobstorage-foo', 'blob-foo2.txt', "Sample blob foo 2.")
     >>> write('var', 'blobstorage-bar', 'blob-bar2.txt', "Sample blob bar 2.")
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -F --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -F --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
@@ -166,7 +166,7 @@ But let's test it for good measure::
     >>> remove('var', 'blobstorage-foo', 'blob-foo1.txt')
     >>> remove('var', 'blobstorage-bar', 'blob-bar1.txt')
     >>> write('var', 'blobstorage', 'blob1.txt', "Sample blob 1 version 2.")
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -F --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -F --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
@@ -229,7 +229,7 @@ sure if this works on all operating systems.
 
 Let's see how a bin/backup goes:
 
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo --quick --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar --quick --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
@@ -269,7 +269,7 @@ We try again with an extra 'blob' and a changed 'blob':
     >>> time.sleep(2)
     >>> write('var', 'blobstorage', 'blob2.txt', "Sample blob 2.")
     >>> write('var', 'blobstorage', 'blob1.txt', "Sample blob 1 version 3.")
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo --quick --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar --quick --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
@@ -310,7 +310,7 @@ Write a third file.
 Now try a restore.
 The third file should be gone afterwards::
 
-    >>> print system('bin/restore', input='no\n')
+    >>> print(system('bin/restore', input='no\n'))
     <BLANKLINE>
     This will replace the filestorage:
         /sample-buildout/var/filestorage/foo.fs
@@ -327,7 +327,7 @@ The third file should be gone afterwards::
     -  blob1.txt
     -  blob2.txt
     -  blob3.txt
-    >>> print system('bin/restore', input='yes\n')
+    >>> print(system('bin/restore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo
     --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups
@@ -364,7 +364,7 @@ With the ``no-prompt`` option we avoid the question::
     -  blob1.txt
     -  blob2.txt
     -  blob3.txt
-    >>> print system('bin/restore --no-prompt')
+    >>> print(system('bin/restore --no-prompt'))
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo
     --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups
@@ -395,7 +395,7 @@ Since we use timestamps, this should be fairly straight forward.
     >>> time_string = backup_timestamp0[len('blobstorage.'):]
     >>> time_string
     '20...-...-...-...-...-...'
-    >>> print system('bin/restore %s' % time_string, input='yes\n')
+    >>> print(system('bin/restore %s' % time_string, input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo -D ...
     --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar -D ...
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups -D ...
@@ -433,7 +433,7 @@ The first blob file is back to an earlier version::
 
 The snapshotrestore works too::
 
-    >>> print system('bin/snapshotrestore', input='yes\n')
+    >>> print(system('bin/snapshotrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo
     --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups
@@ -493,7 +493,7 @@ Since we use timestamps, this should be fairly straight forward.
     >>> time_string = timestamp1[len('blobstorage.'):]
     >>> time_string
     '20...-...-...-...-...-...'
-    >>> print system('bin/snapshotrestore %s' % time_string, input='yes\n')
+    >>> print(system('bin/snapshotrestore %s' % time_string, input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -D ...
     --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -D ...
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -D ...
@@ -558,7 +558,7 @@ Create some archived (gzipped) and not-archived separate backup scripts::
     ... blob_timestamps = true
     ... enable_zipbackup = true
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -571,7 +571,7 @@ Create some archived (gzipped) and not-archived separate backup scripts::
 
 Now we test it::
 
-    >>> print system('bin/zipbackup')
+    >>> print(system('bin/zipbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups -F --gzip
     INFO: Created /sample-buildout/var/zipbackups
     INFO: Created /sample-buildout/var/blobstoragezips
@@ -587,7 +587,7 @@ Keep is ignored by zipbackup, always using 1 as value.
 Pause a short time to avoid getting an error for overwriting the previous file::
 
     >>> time.sleep(1)
-    >>> print system('bin/zipbackup')
+    >>> print(system('bin/zipbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups -F --gzip
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/zipbackups
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragezips
@@ -602,7 +602,7 @@ Pause a short time to avoid getting an error for overwriting the previous file::
 
 Now test the ziprestore script::
 
-    >>> print system('bin/ziprestore', input='yes\n')
+    >>> print(system('bin/ziprestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups
     <BLANKLINE>
     This will replace the filestorage:

--- a/src/collective/recipe/backup/tests/blobs.rst
+++ b/src/collective/recipe/backup/tests/blobs.rst
@@ -14,7 +14,7 @@ Add mock ``bin/repozo`` script::
 
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 New in this recipe is that we backup the blob storage.  Plone 4 uses a
@@ -67,7 +67,7 @@ We run the buildout (and set a timeout as we need a few new packages
 and apparently a few servers are currently down so a timeout helps
 speed things up a bit):
 
-    >>> print system('bin/buildout -t 5')
+    >>> print(system('bin/buildout -t 5'))
     Setting socket time out to 5 seconds.
     Getting distribution for 'plone.recipe.zope2INSTANCE==3.9'...
     Got plone.recipe.zope2instance 3.9.
@@ -125,7 +125,7 @@ Without explicit blob-storage option, it defaults to ``blobstorage`` in the var 
     ... [backup]
     ... recipe = collective.recipe.backup
     ... """)
-    >>> print system('bin/buildout')
+    >>> print(system('bin/buildout'))
     Uninstalling instance.
     Installing instance.
     Updating backup.
@@ -174,7 +174,7 @@ is only for Plone 4 and higher.
     ... [backup]
     ... recipe = collective.recipe.backup
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling instance.
     Updating backup.
     While:
@@ -190,7 +190,7 @@ is only for Plone 4 and higher.
     ... recipe = collective.recipe.backup
     ... backup_blobs = false
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
@@ -212,7 +212,7 @@ We can override the additional_filestorages location:
     ... additional_filestorages =
     ...    catalog ${buildout:directory}/var/filestorage/2.fs
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -238,7 +238,7 @@ We can override the additional_filestorages blob source location:
     ...    withblob    ${buildout:directory}/var/filestorage/2.fs ${buildout:directory}/var/blobstorage2
     ...    withoutblob ${buildout:directory}/var/filestorage/3.fs
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -261,7 +261,7 @@ Wrong configurations for additional_filestorages:
     ... additional_filestorages =
     ...    wrong ${buildout:directory}/var/filestorage foo.fs ${buildout:directory}/var/blobstorage_foo
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     While:
@@ -286,7 +286,7 @@ Full cycle tests:
     ...    foo ${buildout:directory}/var/filestorage/foo.fs ${buildout:directory}/var/blobstorage-foo
     ...    bar ${buildout:directory}/var/filestorage/bar.fs ${buildout:directory}/var/blobstorage-bar/
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
@@ -311,7 +311,7 @@ Full cycle tests:
 
 Test the snapshotbackup first, as that should be easiest.
 
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -F --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -F --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
@@ -352,7 +352,7 @@ easily test restoring to a specific time later.
     >>> write('var', 'blobstorage', 'blob2.txt', "Sample blob 2.")
     >>> write('var', 'blobstorage-foo', 'blob-foo2.txt', "Sample blob foo 2.")
     >>> write('var', 'blobstorage-bar', 'blob-bar2.txt', "Sample blob bar 2.")
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -F --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -F --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
@@ -404,7 +404,7 @@ Now remove an item:
     >>> remove('var', 'blobstorage', 'blob2.txt')
     >>> remove('var', 'blobstorage-foo', 'blob-foo1.txt')
     >>> remove('var', 'blobstorage-bar', 'blob-bar1.txt')
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -F --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -F --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
@@ -449,7 +449,7 @@ Now remove an item:
 
 Let's see how a bin/backup goes:
 
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo --quick --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar --quick --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
@@ -486,7 +486,7 @@ We try again with an extra 'blob':
 
     >>> time.sleep(2)
     >>> write('var', 'blobstorage', 'blob2.txt', "Sample blob 2.")
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo --quick --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar --quick --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
@@ -532,7 +532,7 @@ copies, so also in this case the inodes can be the same::
 
 Now try a restore::
 
-    >>> print system('bin/restore', input='no\n')
+    >>> print(system('bin/restore', input='no\n'))
     <BLANKLINE>
     This will replace the filestorage:
         /sample-buildout/var/filestorage/foo.fs
@@ -545,7 +545,7 @@ Now try a restore::
     Are you sure? (yes/No)?
     INFO: Not restoring.
     <BLANKLINE>
-    >>> print system('bin/restore', input='yes\n')
+    >>> print(system('bin/restore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo
     --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups
@@ -575,7 +575,7 @@ Now try a restore::
 
 With the ``no-prompt`` option we avoid the question::
 
-    >>> print system('bin/restore --no-prompt')
+    >>> print(system('bin/restore --no-prompt'))
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo
     --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups
@@ -616,7 +616,7 @@ tests due to rounding or similar sillyness.
     >>> mod_time_1 = os.path.getmtime('var/blobstoragebackups_foo/blobstorage-foo.1')
     >>> mod_time_0 > mod_time_1
     True
-    >>> print system('bin/restore %s' % time_string, input='yes\n')
+    >>> print(system('bin/restore %s' % time_string, input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo -D ...
     --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar -D ...
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups -D ...
@@ -649,7 +649,7 @@ The second blob file is now no longer in the blob storage.
 
 When passed a date for which we have no backups, the script will fail.
 
-    >>> print system('bin/restore 1972-12-25', input='yes\n')
+    >>> print(system('bin/restore 1972-12-25', input='yes\n'))
     <BLANKLINE>
     This will replace the filestorage:
         /sample-buildout/var/filestorage/foo.fs
@@ -667,7 +667,7 @@ When passed a date for which we have no backups, the script will fail.
 
 The snapshotrestore works too::
 
-    >>> print system('bin/snapshotrestore', input='yes\n')
+    >>> print(system('bin/snapshotrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo
     --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups
@@ -718,7 +718,7 @@ Since release 2.3 we can also restore blob snapshots to a specific date/time.
     >>> mod_time_1 > mod_time_2
     True
     >>> time_string = '-'.join(['{0:02d}'.format(t) for t in datetime.utcfromtimestamp(mod_time_1 + 1).timetuple()[:6]])
-    >>> print system('bin/snapshotrestore %s' % time_string, input='yes\n')
+    >>> print(system('bin/snapshotrestore %s' % time_string, input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -D ...
     --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -D ...
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -D ...
@@ -756,7 +756,7 @@ We test that with a special bin/repozo script that simply quits::
 
     >>> write('bin', 'repozo', "#!%s\nimport sys\nsys.exit(1)" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
-    >>> print system('bin/snapshotrestore', input='yes\n')
+    >>> print(system('bin/snapshotrestore', input='yes\n'))
     <BLANKLINE>
     This will replace the filestorage:
         /sample-buildout/var/filestorage/foo.fs
@@ -775,7 +775,7 @@ We test that with a special bin/repozo script that simply quits::
 Restore the original bin/repozo::
 
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 
@@ -795,7 +795,7 @@ blob_storage option, otherwise buildout quits::
     ... recipe = collective.recipe.backup
     ... backup_blobs = true
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     While:
@@ -817,7 +817,7 @@ Combining blob_backup=false and only_blobs=true will not work::
     ... backup_blobs = false
     ... only_blobs = true
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     While:
       Installing.
       Getting section backup.
@@ -846,7 +846,7 @@ enable_zipbackup too::
     ... only_blobs = true
     ... enable_zipbackup = true
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing filebackup.
     Generated script '/sample-buildout/bin/filebackup'.
     Generated script '/sample-buildout/bin/filebackup-snapshot'.
@@ -864,7 +864,7 @@ enable_zipbackup too::
 Now we test it.  First the backup.  The filebackup now only backs up
 the filestorage::
 
-    >>> print system('bin/filebackup')
+    >>> print(system('bin/filebackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/filebackups --quick --gzip
     INFO: Created /sample-buildout/var/filebackups
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/filebackups
@@ -872,7 +872,7 @@ the filestorage::
 
 blobbackup only backs up the blobstorage::
 
-    >>> print system('bin/blobbackup')
+    >>> print(system('bin/blobbackup'))
     INFO: Created /sample-buildout/var/blobbackup-blobstorages
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobbackup-blobstorages
     INFO: rsync -a  /sample-buildout/var/blobstorage /sample-buildout/var/blobbackup-blobstorages/blobstorage.0
@@ -880,12 +880,12 @@ blobbackup only backs up the blobstorage::
 
 Test the snapshots as well::
 
-    >>> print system('bin/filebackup-snapshot')
+    >>> print(system('bin/filebackup-snapshot'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/filebackup-snapshots -F --gzip
     INFO: Created /sample-buildout/var/filebackup-snapshots
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/filebackup-snapshots
     <BLANKLINE>
-    >>> print system('bin/blobbackup-snapshot')
+    >>> print(system('bin/blobbackup-snapshot'))
     INFO: Created /sample-buildout/var/blobbackup-blobstoragesnapshots
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobbackup-blobstoragesnapshots
     INFO: rsync -a  /sample-buildout/var/blobstorage /sample-buildout/var/blobbackup-blobstoragesnapshots/blobstorage.0
@@ -893,7 +893,7 @@ Test the snapshots as well::
 
 Now test the restore::
 
-    >>> print system('bin/filebackup-restore', input='yes\n')
+    >>> print(system('bin/filebackup-restore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/filebackups
     <BLANKLINE>
     This will replace the filestorage:
@@ -901,7 +901,7 @@ Now test the restore::
     Are you sure? (yes/No)?
     INFO: Please wait while restoring database file: /sample-buildout/var/filebackups to /sample-buildout/var/filestorage/Data.fs
     <BLANKLINE>
-    >>> print system('bin/filebackup-snapshotrestore', input='yes\n')
+    >>> print(system('bin/filebackup-snapshotrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/filebackup-snapshots
     <BLANKLINE>
     This will replace the filestorage:
@@ -909,7 +909,7 @@ Now test the restore::
     Are you sure? (yes/No)?
     INFO: Please wait while restoring database file: /sample-buildout/var/filebackup-snapshots to /sample-buildout/var/filestorage/Data.fs
     <BLANKLINE>
-    >>> print system('bin/blobbackup-restore', input='yes\n')
+    >>> print(system('bin/blobbackup-restore', input='yes\n'))
     <BLANKLINE>
     This will replace the blobstorage:
         /sample-buildout/var/blobstorage
@@ -917,7 +917,7 @@ Now test the restore::
     INFO: Restoring blobs from /sample-buildout/var/blobbackup-blobstorages to /sample-buildout/var/blobstorage
     INFO: rsync -a  --delete /sample-buildout/var/blobbackup-blobstorages/blobstorage.0/blobstorage /sample-buildout/var
     <BLANKLINE>
-    >>> print system('bin/blobbackup-snapshotrestore', input='yes\n')
+    >>> print(system('bin/blobbackup-snapshotrestore', input='yes\n'))
     <BLANKLINE>
     This will replace the blobstorage:
         /sample-buildout/var/blobstorage
@@ -948,7 +948,7 @@ restore to ensure passing of extra options to rsync works::
     ... blob_storage = ${buildout:directory}/var/blobstorage
     ... rsync_options = --no-l -k
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling blobbackup.
     Uninstalling filebackup.
     Installing backup.
@@ -966,7 +966,7 @@ restore to ensure passing of extra options to rsync works::
     - restore
     - snapshotbackup
     - snapshotrestore
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/backups
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragebackups
@@ -1003,7 +1003,7 @@ So backup still works, now test restore that uses a symlinked directory as the b
     ... pre_command = ln -s ${buildout:directory}/var/blobstoragebackups/blobstorage.0/blobstorage ${backup:blobbackuplocation}/blobstorage.0/blobstorage
     ... post_command = unlink ${backup:blobbackuplocation}/blobstorage.0/blobstorage
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -1020,7 +1020,7 @@ So backup still works, now test restore that uses a symlinked directory as the b
     - restore
     - snapshotbackup
     - snapshotrestore
-    >>> print system('bin/restore --no-prompt')
+    >>> print(system('bin/restore --no-prompt'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups
     <BLANKLINE>
     INFO: Please wait while restoring database file: /sample-buildout/var/backups to /sample-buildout/var/filestorage/Data.fs
@@ -1044,7 +1044,7 @@ See issue #26. So test what happens:
     ... recipe = collective.recipe.backup
     ... blob_storage = ${buildout:directory}/var/blobstorage/
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -1052,7 +1052,7 @@ See issue #26. So test what happens:
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
     <BLANKLINE>
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/backups
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragebackups

--- a/src/collective/recipe/backup/tests/gzip.rst
+++ b/src/collective/recipe/backup/tests/gzip.rst
@@ -11,7 +11,7 @@ Add mock ``bin/repozo`` script::
 
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 Create directories and content::
@@ -50,7 +50,7 @@ Create some archived (gzipped) and not-archived separate backup scripts::
     ... archive_blob = true
     ... compress_blob = true
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing nozipbackup.
     Generated script '/sample-buildout/bin/nozipbackup'.
     Generated script '/sample-buildout/bin/nozipbackup-snapshot'.
@@ -71,7 +71,7 @@ Create some archived (gzipped) and not-archived separate backup scripts::
 Now we test it.  First the `normal` backup.  The nozipbackup backs up without
 using archiving technology::
 
-    >>> print system('bin/nozipbackup')
+    >>> print(system('bin/nozipbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/nozipbackups --quick
     INFO: Created /sample-buildout/var/nozipbackups
     INFO: Created /sample-buildout/var/nozipbackup-blobstorages
@@ -79,7 +79,7 @@ using archiving technology::
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/nozipbackup-blobstorages
     INFO: rsync -a  /sample-buildout/var/blobstorage /sample-buildout/var/nozipbackup-blobstorages/blobstorage.0
     <BLANKLINE>
-    >>> print system('bin/nozipbackup-snapshot')
+    >>> print(system('bin/nozipbackup-snapshot'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/nozipbackup-snapshots -F
     INFO: Created /sample-buildout/var/nozipbackup-snapshots
     INFO: Created /sample-buildout/var/nozipbackup-blobstoragesnapshots
@@ -90,7 +90,7 @@ using archiving technology::
 
 zippedbackup backs up by gzipping the filestorage backup and archiving the blob backup with tar::
 
-    >>> print system('bin/zippedbackup')
+    >>> print(system('bin/zippedbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zippedbackups --quick --gzip
     INFO: Created /sample-buildout/var/zippedbackups
     INFO: Created /sample-buildout/var/zippedbackup-blobstorages
@@ -98,7 +98,7 @@ zippedbackup backs up by gzipping the filestorage backup and archiving the blob 
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/zippedbackup-blobstorages
     INFO: tar cf /sample-buildout/var/zippedbackup-blobstorages/blobstorage.0.tar -C /sample-buildout/var/blobstorage .
     <BLANKLINE>
-    >>> print system('bin/zippedbackup-snapshot')
+    >>> print(system('bin/zippedbackup-snapshot'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zippedbackup-snapshots -F --gzip
     INFO: Created /sample-buildout/var/zippedbackup-snapshots
     INFO: Created /sample-buildout/var/zippedbackup-blobstoragesnapshots
@@ -110,7 +110,7 @@ zippedbackup backs up by gzipping the filestorage backup and archiving the blob 
 
 And compressedbackup compresses the blob archive::
 
-    >>> print system('bin/compressedbackup')
+    >>> print(system('bin/compressedbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/compressedbackups --quick --gzip
     INFO: Created /sample-buildout/var/compressedbackups
     INFO: Created /sample-buildout/var/compressedbackup-blobstorages
@@ -118,7 +118,7 @@ And compressedbackup compresses the blob archive::
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/compressedbackup-blobstorages
     INFO: tar czf /sample-buildout/var/compressedbackup-blobstorages/blobstorage.0.tar.gz -C /sample-buildout/var/blobstorage .
     <BLANKLINE>
-    >>> print system('bin/compressedbackup-snapshot')
+    >>> print(system('bin/compressedbackup-snapshot'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/compressedbackup-snapshots -F --gzip
     INFO: Created /sample-buildout/var/compressedbackup-snapshots
     INFO: Created /sample-buildout/var/compressedbackup-blobstoragesnapshots
@@ -130,7 +130,7 @@ And compressedbackup compresses the blob archive::
 
 Now test the restore::
 
-    >>> print system('bin/nozipbackup-restore', input='yes\n')
+    >>> print(system('bin/nozipbackup-restore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/nozipbackups
     <BLANKLINE>
     This will replace the filestorage:
@@ -143,7 +143,7 @@ Now test the restore::
     INFO: Restoring blobs from /sample-buildout/var/nozipbackup-blobstorages to /sample-buildout/var/blobstorage
     INFO: rsync -a  --delete /sample-buildout/var/nozipbackup-blobstorages/blobstorage.0/blobstorage /sample-buildout/var
     <BLANKLINE>
-    >>> print system('bin/nozipbackup-snapshotrestore', input='yes\n')
+    >>> print(system('bin/nozipbackup-snapshotrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/nozipbackup-snapshots
     <BLANKLINE>
     This will replace the filestorage:
@@ -154,7 +154,7 @@ Now test the restore::
     INFO: Restoring blobs from /sample-buildout/var/nozipbackup-blobstoragesnapshots to /sample-buildout/var/blobstorage
     INFO: rsync -a  --delete /sample-buildout/var/nozipbackup-blobstoragesnapshots/blobstorage.0/blobstorage /sample-buildout/var
     <BLANKLINE>
-    >>> print system('bin/zippedbackup-restore', input='yes\n')
+    >>> print(system('bin/zippedbackup-restore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zippedbackups
     <BLANKLINE>
     This will replace the filestorage:
@@ -167,7 +167,7 @@ Now test the restore::
     INFO: Extracting /sample-buildout/var/zippedbackup-blobstorages/blobstorage.0.tar to /sample-buildout/var/blobstorage
     INFO: tar xf /sample-buildout/var/zippedbackup-blobstorages/blobstorage.0.tar -C /sample-buildout/var/blobstorage
     <BLANKLINE>
-    >>> print system('bin/zippedbackup-snapshotrestore', input='yes\n')
+    >>> print(system('bin/zippedbackup-snapshotrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zippedbackup-snapshots
     <BLANKLINE>
     This will replace the filestorage:
@@ -180,7 +180,7 @@ Now test the restore::
     INFO: Extracting /sample-buildout/var/zippedbackup-blobstoragesnapshots/blobstorage.0.tar to /sample-buildout/var/blobstorage
     INFO: tar xf /sample-buildout/var/zippedbackup-blobstoragesnapshots/blobstorage.0.tar -C /sample-buildout/var/blobstorage
     <BLANKLINE>
-    >>> print system('bin/compressedbackup-restore', input='yes\n')
+    >>> print(system('bin/compressedbackup-restore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/compressedbackups
     <BLANKLINE>
     This will replace the filestorage:
@@ -193,7 +193,7 @@ Now test the restore::
     INFO: Extracting /sample-buildout/var/compressedbackup-blobstorages/blobstorage.0.tar.gz to /sample-buildout/var/blobstorage
     INFO: tar xzf /sample-buildout/var/compressedbackup-blobstorages/blobstorage.0.tar.gz -C /sample-buildout/var/blobstorage
     <BLANKLINE>
-    >>> print system('bin/compressedbackup-snapshotrestore', input='yes\n')
+    >>> print(system('bin/compressedbackup-snapshotrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/compressedbackup-snapshots
     <BLANKLINE>
     This will replace the filestorage:

--- a/src/collective/recipe/backup/tests/location.rst
+++ b/src/collective/recipe/backup/tests/location.rst
@@ -11,7 +11,7 @@ Add mock ``bin/repozo`` script::
 
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 You should not mix backup locations; it is confusing for the recipe
@@ -31,7 +31,7 @@ You should not mix backup locations; it is confusing for the recipe
     ... snapshotlocation = ${buildout:directory}/var/loc2
     ... blobsnapshotlocation = ${buildout:directory}/var/loc2
     ... """)
-    >>> print system('bin/buildout')
+    >>> print(system('bin/buildout'))
     While:
       Installing.
       Getting section backup.
@@ -63,7 +63,7 @@ is probably grudgingly allowed, at least by this particular check.
     ... ziplocation =
     ... blobziplocation =
     ... """)
-    >>> print system('bin/buildout')
+    >>> print(system('bin/buildout'))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/zipbackup'.
@@ -93,7 +93,7 @@ We'll use all options, except the blob options for now::
     ... backup_blobs = false
     ... location = /my/unusable/path/for/backup
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     utils: WARNING: Not able to create /my/unusable/path/for/backup

--- a/src/collective/recipe/backup/tests/multiple.rst
+++ b/src/collective/recipe/backup/tests/multiple.rst
@@ -11,7 +11,7 @@ Add mock ``bin/repozo`` script::
 
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 Create var directory::
@@ -42,7 +42,7 @@ The additional backups have to be stored separate from the ``Data.fs``
 backup. That's done by appending the file's name and creating extra backup
 directories named that way::
 
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
@@ -56,7 +56,7 @@ same time with repozo. So they are not completely in sync. The "other"
 databases are backed up first as a small difference in the catalog is just
 mildly irritating, but the other way around users can get real errors::
 
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/catalog.fs -r /sample-buildout/var/backups_catalog --quick --gzip
     --backup -f /sample-buildout/var/filestorage/another.fs -r /sample-buildout/var/backups_another --quick --gzip
     --backup -f /sample-buildout/var/filestorage/foo/bar.fs -r /sample-buildout/var/backups_foo/bar --quick --gzip
@@ -78,7 +78,7 @@ mildly irritating, but the other way around users can get real errors::
 
 Same with snapshot backups::
 
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/catalog.fs -r /sample-buildout/var/snapshotbackups_catalog -F --gzip
     --backup -f /sample-buildout/var/filestorage/another.fs -r /sample-buildout/var/snapshotbackups_another -F --gzip
     --backup -f /sample-buildout/var/filestorage/foo/bar.fs -r /sample-buildout/var/snapshotbackups_foo/bar -F --gzip
@@ -95,7 +95,7 @@ Same with snapshot backups::
 
 And a restore restores all three backups::
 
-    >>> print system('bin/restore', input='yes\n')
+    >>> print(system('bin/restore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/catalog.fs -r /sample-buildout/var/backups_catalog
     --recover -o /sample-buildout/var/filestorage/another.fs -r /sample-buildout/var/backups_another
     --recover -o /sample-buildout/var/filestorage/foo/bar.fs -r /sample-buildout/var/backups_foo/bar
@@ -137,7 +137,7 @@ test if the 'keep' parameter is working correctly.
     -  0.fs
     -  1.fs
     -  2.fs
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/catalog.fs -r /sample-buildout/var/backups_catalog --quick --gzip
     --backup -f /sample-buildout/var/filestorage/another.fs -r /sample-buildout/var/backups_another --quick --gzip
     --backup -f /sample-buildout/var/filestorage/foo/bar.fs -r /sample-buildout/var/backups_foo/bar --quick --gzip
@@ -157,7 +157,7 @@ test if the 'keep' parameter is working correctly.
 
 Same for the snapshot backups:
 
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/catalog.fs -r /sample-buildout/var/snapshotbackups_catalog -F --gzip
     --backup -f /sample-buildout/var/filestorage/another.fs -r /sample-buildout/var/snapshotbackups_another -F --gzip
     --backup -f /sample-buildout/var/filestorage/foo/bar.fs -r /sample-buildout/var/snapshotbackups_foo/bar -F --gzip

--- a/src/collective/recipe/backup/tests/no_rsync.rst
+++ b/src/collective/recipe/backup/tests/no_rsync.rst
@@ -11,7 +11,7 @@ Add mock ``bin/repozo`` script::
 
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 If you cannot use rsync and hard links (which may not work on Windows)
@@ -38,7 +38,7 @@ First we create some fresh content:
 One thing we test here is if the buildout does not create too many
 directories that will not get used because have set only_blobs=true::
 
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
@@ -52,7 +52,7 @@ nowhere to be found::
     >>> output = system('bin/backup')
     >>> 'rsync' in output
     False
-    >>> print output
+    >>> print(output)
     INFO: Created /sample-buildout/var/blobstoragebackups
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragebackups
     INFO: Copying /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragebackups/blobstorage.0/blobstorage
@@ -63,7 +63,7 @@ Try again to see that renaming/rotating keeps working::
     >>> output = system('bin/backup')
     >>> 'rsync' in output
     False
-    >>> print output
+    >>> print(output)
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragebackups
     INFO: Renaming blobstorage.0 to blobstorage.1.
     INFO: Copying /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragebackups/blobstorage.0/blobstorage
@@ -74,7 +74,7 @@ And again to see that for incremental backups no old blob backups are removed::
     >>> output = system('bin/backup')
     >>> 'rsync' in output
     False
-    >>> print output
+    >>> print(output)
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragebackups
     INFO: Renaming blobstorage.1 to blobstorage.2.
     INFO: Renaming blobstorage.0 to blobstorage.1.
@@ -86,7 +86,7 @@ Now a restore::
     >>> output = system('bin/restore', input='yes\n')
     >>> 'rsync' in output
     False
-    >>> print output
+    >>> print(output)
     <BLANKLINE>
     This will replace the blobstorage:
         /sample-buildout/var/blobstorage
@@ -101,7 +101,7 @@ Snapshots should work too::
     >>> output = system('bin/snapshotbackup')
     >>> 'rsync' in output
     False
-    >>> print output
+    >>> print(output)
     INFO: Created /sample-buildout/var/blobstoragesnapshots
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragesnapshots
     INFO: Copying /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragesnapshots/blobstorage.0/blobstorage
@@ -112,7 +112,7 @@ Try again to see that renaming/rotating keeps working::
     >>> output = system('bin/snapshotbackup')
     >>> 'rsync' in output
     False
-    >>> print output
+    >>> print(output)
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragesnapshots
     INFO: Renaming blobstorage.0 to blobstorage.1.
     INFO: Copying /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragesnapshots/blobstorage.0/blobstorage
@@ -123,7 +123,7 @@ And again to see that removing old backups works::
     >>> output = system('bin/snapshotbackup')
     >>> 'rsync' in output
     False
-    >>> print output
+    >>> print(output)
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragesnapshots
     INFO: Renaming blobstorage.1 to blobstorage.2.
     INFO: Renaming blobstorage.0 to blobstorage.1.
@@ -136,7 +136,7 @@ And the snapshotrestore::
     >>> output = system('bin/snapshotrestore', input='yes\n')
     >>> 'rsync' in output
     False
-    >>> print output
+    >>> print(output)
     <BLANKLINE>
     This will replace the blobstorage:
         /sample-buildout/var/blobstorage

--- a/src/collective/recipe/backup/tests/options.rst
+++ b/src/collective/recipe/backup/tests/options.rst
@@ -11,7 +11,7 @@ Add mock ``bin/repozo`` script::
 
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 We'll use most options, except the blob options for now::
@@ -38,7 +38,7 @@ We'll use most options, except the blob options for now::
     ...     echo 'Thanks a lot for the backup.'
     ...     echo 'We are done.'
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/snapshotbackup'.
@@ -54,7 +54,7 @@ because several things conspire in the tests to mess up stdout and
 stderr.  Anyway::
 
     >>> output = system('bin/backup')
-    >>> print output
+    >>> print(output)
     --backup -f /sample-buildout/subfolder/myproject.fs -r /sample-buildout/myproject --quick -F --verbose
     Can I have a backup?
     <BLANKLINE>
@@ -66,12 +66,12 @@ stderr.  Anyway::
 
 We explicitly look for errors here::
 
-    >>> if 'ERROR' in output: print output
+    >>> if 'ERROR' in output: print(output)
 
 The same is true for the snapshot backup.
 
     >>> output = system('bin/snapshotbackup')
-    >>> print output
+    >>> print(output)
     --backup -f /sample-buildout/subfolder/myproject.fs -r /sample-buildout/var/snap/my -F --verbose
     Can I have a backup?
     Thanks a lot for the backup.
@@ -79,7 +79,7 @@ The same is true for the snapshot backup.
     20...-...-... INFO: Created /sample-buildout/var/snap/my
     20...-...-... INFO: Please wait while making snapshot backup: /sample-buildout/subfolder/myproject.fs to /sample-buildout/var/snap/my
     20...-...-...
-    >>> if 'ERROR' in output: print output
+    >>> if 'ERROR' in output: print(output)
 
 Untested in this file, as it would create directories in your root or your
 home dir, are absolute links (starting with a '/') or directories in your home
@@ -98,12 +98,12 @@ get, as you'll get that in your mailbox. In your cronjob, just add ``-q`` or
 In the tests, we do get messages unfortunately, though at least the
 INFO level logging is not there::
 
-    >>> print system('bin/backup -q')
+    >>> print(system('bin/backup -q'))
     --backup -f /sample-buildout/subfolder/myproject.fs -r /sample-buildout/myproject --quick -F --verbose
     Can I have a backup?
     Thanks a lot for the backup.
     We are done.
-    >>> print system('bin/backup --quiet')
+    >>> print(system('bin/backup --quiet'))
     --backup -f /sample-buildout/subfolder/myproject.fs -r /sample-buildout/myproject --quick -F --verbose
     Can I have a backup?
     Thanks a lot for the backup.
@@ -143,7 +143,7 @@ generated script).
     ... enable_snapshotrestore = false
     ... """)
 
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -179,7 +179,7 @@ wanted.
     ... quick = false
     ... """)
 
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -187,7 +187,7 @@ wanted.
     Generated script '/sample-buildout/bin/restore'.
     Generated script '/sample-buildout/bin/snapshotrestore'.
     <BLANKLINE>
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --gzip
     INFO: Created /sample-buildout/var/backups
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/backups
@@ -213,7 +213,7 @@ The fullbackup script should be generated now.
     ... enable_fullbackup = true
     ... """)
 
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.

--- a/src/collective/recipe/backup/tests/prefix.rst
+++ b/src/collective/recipe/backup/tests/prefix.rst
@@ -45,12 +45,12 @@ Some needed imports:
 
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 By default, backups are done in ``backuplocation/backups``::
 
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/backups --quick --gzip
     INFO: Created /sample-buildout/backuplocation/backups
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/backuplocation/backups
@@ -58,7 +58,7 @@ By default, backups are done in ``backuplocation/backups``::
 
 Full backups are placed there too::
 
-    >>> print system('bin/fullbackup')
+    >>> print(system('bin/fullbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/backups -F --gzip
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/backuplocation/backups
     <BLANKLINE>
@@ -72,7 +72,7 @@ This will create the target directory when it does not exist::
 
     >>> ls('backuplocation')
     d  backups
-    >>> print system('bin/restore', input='yes\n')
+    >>> print(system('bin/restore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/backups
     <BLANKLINE>
     This will replace the filestorage:
@@ -89,7 +89,7 @@ You can also restore the backup as of a certain date. Just pass a date
 argument. According to repozo: specify UTC (not local) time.  The format is
 ``yyyy-mm-dd[-hh[-mm[-ss]]]``.
 
-    >>> print system('bin/restore 1972-12-25', input='yes\n')
+    >>> print(system('bin/restore 1972-12-25', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/backups -D 1972-12-25
     <BLANKLINE>
     This will replace the filestorage:
@@ -112,7 +112,7 @@ backup just before updating the production server is a good idea. For that,
 the ``bin/snapshotbackup`` is great. It places a full backup in, by default,
 ``var/snapshotbackups``.
 
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/snapshotbackups -F --gzip
     INFO: Created /sample-buildout/backuplocation/snapshotbackups
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/backuplocation/snapshotbackups
@@ -120,7 +120,7 @@ the ``bin/snapshotbackup`` is great. It places a full backup in, by default,
 
 You can restore the very latest snapshotbackup with ``bin/snapshotrestore``::
 
-    >>> print system('bin/snapshotrestore', input='yes\n')
+    >>> print(system('bin/snapshotrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/snapshotbackups
     <BLANKLINE>
     This will replace the filestorage:
@@ -158,7 +158,7 @@ A prefix plus relative locations should result in locations relative to the pref
 
 Let's run the buildout::
 
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -171,7 +171,7 @@ Let's run the buildout::
 
 And run the scripts::
 
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/std/datafs --quick --gzip
     INFO: Created /sample-buildout/backuplocation/std/datafs
     INFO: Created /sample-buildout/backuplocation/std/blobs
@@ -183,7 +183,7 @@ And run the scripts::
     d  blobstorage
     >>> ls('backuplocation', 'std', 'blobs', 'blobstorage.0', 'blobstorage')
     -  blob.txt
-    >>> print system('bin/zipbackup')
+    >>> print(system('bin/zipbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/snapshots/zip -F --gzip
     INFO: Created /sample-buildout/backuplocation/snapshots/zip
     INFO: Created /sample-buildout/backuplocation/snapshots/zipblobs
@@ -191,7 +191,7 @@ And run the scripts::
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/backuplocation/snapshots/zipblobs
     INFO: tar cf /sample-buildout/backuplocation/snapshots/zipblobs/blobstorage.0.tar -C /sample-buildout/var/blobstorage .
     <BLANKLINE>
-    >>> print system('bin/snapshotbackup')
+    >>> print(system('bin/snapshotbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/snapshots/datafs -F --gzip
     INFO: Created /sample-buildout/backuplocation/snapshots/datafs
     INFO: Created /sample-buildout/backuplocation/snapshots/blobs
@@ -199,7 +199,7 @@ And run the scripts::
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage to /sample-buildout/backuplocation/snapshots/blobs
     INFO: rsync -a  /sample-buildout/var/blobstorage /sample-buildout/backuplocation/snapshots/blobs/blobstorage.0
     <BLANKLINE>
-    >>> print system('bin/restore', input='yes\n')
+    >>> print(system('bin/restore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/std/datafs
     <BLANKLINE>
     This will replace the filestorage:
@@ -211,7 +211,7 @@ And run the scripts::
     INFO: Restoring blobs from /sample-buildout/backuplocation/std/blobs to /sample-buildout/var/blobstorage
     INFO: rsync -a  --delete /sample-buildout/backuplocation/std/blobs/blobstorage.0/blobstorage /sample-buildout/var
     <BLANKLINE>
-    >>> print system('bin/ziprestore', input='yes\n')
+    >>> print(system('bin/ziprestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/snapshots/zip
     <BLANKLINE>
     This will replace the filestorage:
@@ -225,7 +225,7 @@ And run the scripts::
     INFO: Extracting /sample-buildout/backuplocation/snapshots/zipblobs/blobstorage.0.tar to /sample-buildout/var/blobstorage
     INFO: tar xf /sample-buildout/backuplocation/snapshots/zipblobs/blobstorage.0.tar -C /sample-buildout/var/blobstorage
     <BLANKLINE>
-    >>> print system('bin/snapshotrestore', input='yes\n')
+    >>> print(system('bin/snapshotrestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/snapshots/datafs
     <BLANKLINE>
     This will replace the filestorage:
@@ -261,7 +261,7 @@ A prefix plus absolute locations should result in ignoring the prefix.
 
 Let's run the buildout::
 
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -272,7 +272,7 @@ Let's run the buildout::
 
 And run the scripts::
 
-    >>> print system('bin/backup')
+    >>> print(system('bin/backup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/myownbackup/datafs --quick --gzip
     INFO: Created /sample-buildout/myownbackup/datafs
     INFO: Created /sample-buildout/myownbackup/blobs
@@ -302,7 +302,7 @@ something else,  the script names will also be different as will the created
     ... locationprefix = ${buildout:directory}/backuplocation
     ... enable_fullbackup = true
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing plonebackup.
     Generated script '/sample-buildout/bin/plonebackup'.

--- a/src/collective/recipe/backup/tests/test_unit.py
+++ b/src/collective/recipe/backup/tests/test_unit.py
@@ -173,31 +173,29 @@ class CopyBlobsTestCase(unittest.TestCase):
                          ('a', '1'))
         self.assertFalse(gpn('a.1.tar.gz', suffixes=['tar', 'tgz']))
 
-    def test_strict_cmp_numbers(self):
-        from collective.recipe.backup.copyblobs import strict_cmp_numbers
+    def test_number_key(self):
         from collective.recipe.backup.copyblobs import number_key
-        self.assertEqual(strict_cmp_numbers('0', '1'), -1)
-        self.assertEqual(strict_cmp_numbers('0', '0'), 0)
-        self.assertEqual(strict_cmp_numbers('1', '0'), 1)
-        self.assertEqual(strict_cmp_numbers('9', '10'), -1)
-        self.assertEqual(strict_cmp_numbers('99', '10'), 1)
+        self.assertGreater(number_key('0'), number_key('1'))
+        self.assertEqual(number_key('0'), number_key('0'))
+        self.assertLess(number_key('1'), number_key('0'))
+        self.assertGreater(number_key('9'), number_key('10'))
+        self.assertLess(number_key('99'), number_key('10'))
 
-        # Compare integers and timestamps.  Time stamps are smaller.
-        self.assertEqual(
-            strict_cmp_numbers('0', '1999-12-31-23-59-30'), 1)
-        self.assertEqual(
-            strict_cmp_numbers('1999-12-31-23-59-30', '0'), -1)
+        # Compare integers and timestamps.  Time stamps are more recent,
+        # so they are larger.
+        self.assertLess(number_key('0'), number_key('1999-12-31-23-59-30'))
+        self.assertGreater(number_key('1999-12-31-23-59-30'), number_key('0'))
 
-        # Compare timestamps.  Newest first.
+        # Compare timestamps.  Newest last.
+        self.assertLess(
+            number_key('1999-12-31-23-59-30'),
+            number_key('2000-12-31-23-59-30'))
+        self.assertGreater(
+            number_key('2000-12-31-23-59-30'),
+            number_key('1999-12-31-23-59-30'))
         self.assertEqual(
-            strict_cmp_numbers('1999-12-31-23-59-30',
-                               '2000-12-31-23-59-30'), 1)
-        self.assertEqual(
-            strict_cmp_numbers('2000-12-31-23-59-30',
-                               '1999-12-31-23-59-30'), -1)
-        self.assertEqual(
-            strict_cmp_numbers('1999-12-31-23-59-30',
-                               '1999-12-31-23-59-30'), 0)
+            number_key('1999-12-31-23-59-30'),
+            number_key('1999-12-31-23-59-30'))
 
         # Check the effect on a complete sort.
         # We usually want it reversed.
@@ -241,27 +239,27 @@ class CopyBlobsTestCase(unittest.TestCase):
                 '1999-12-31-23-59-30',
                 '2017-01-02-03-04-05'])
 
-    def test_strict_cmp_backups(self):
-        from collective.recipe.backup.copyblobs import strict_cmp_backups
+    def test_backup_key(self):
         from collective.recipe.backup.copyblobs import backup_key
-        self.assertEqual(strict_cmp_backups('foo.0', 'foo.1'), -1)
-        self.assertEqual(strict_cmp_backups('foo.0', 'foo.0'), 0)
-        self.assertEqual(strict_cmp_backups('foo.1', 'foo.0'), 1)
-        self.assertEqual(strict_cmp_backups('foo.9', 'foo.10'), -1)
+        self.assertGreater(backup_key('foo.0'), backup_key('foo.1'))
+        self.assertEqual(backup_key('foo.0'), backup_key('foo.0'))
+        self.assertLess(backup_key('foo.1'), backup_key('foo.0'))
+        self.assertGreater(backup_key('foo.9'), backup_key('foo.10'))
 
-        # Not the same start for directories:
-        self.assertRaises(ValueError, strict_cmp_backups, 'foo.1', 'bar.1')
+        # You should only compare names with the same start for directories,
+        # but that is not the job of the key.
+        self.assertEqual(backup_key('foo.1'), backup_key('bar.1'))
 
-        # Compare integers and timestamps.  Time stamps are smaller.
-        self.assertEqual(
-            strict_cmp_backups('foo.0', 'foo.1999-12-31-23-59-30'), 1)
+        # Compare integers and timestamps.  Time stamps are last.
+        self.assertLess(
+            backup_key('foo.0'), backup_key('foo.1999-12-31-23-59-30'))
 
-        # Compare timestamps.  Newest first.
-        self.assertEqual(
-            strict_cmp_backups('foo.1999-12-31-23-59-30',
-                               'foo.2000-12-31-23-59-30'), 1)
+        # Compare timestamps.  Newest last.
+        self.assertLess(
+            backup_key('foo.1999-12-31-23-59-30'),
+            backup_key('foo.2000-12-31-23-59-30'))
 
-        # It let's most of the logic be handled in strict_cmp_numbers,
+        # It let's most of the logic be handled in number_key,
         # so let's take over one more test from there.
         self.assertEqual(
             sorted([
@@ -276,19 +274,47 @@ class CopyBlobsTestCase(unittest.TestCase):
                 'foo.1999-12-31-23-59-30',
                 'foo.2017-01-02-03-04-05'])
 
-    def test_strict_cmp_gzips(self):
-        from collective.recipe.backup.copyblobs import strict_cmp_gzips
+    def test_archive_backup_key(self):
         from collective.recipe.backup.copyblobs import archive_backup_key
-        self.assertEqual(strict_cmp_gzips('foo.0.tar.gz', 'foo.1.tar.gz'), -1)
-        self.assertEqual(strict_cmp_gzips('foo.0.tar.gz', 'foo.0.tar.gz'), 0)
-        self.assertEqual(strict_cmp_gzips('foo.1.tar.gz', 'foo.0.tar.gz'), 1)
-        self.assertEqual(strict_cmp_gzips('foo.9.tar.gz', 'foo.10.tar.gz'), -1)
+        self.assertGreater(
+            archive_backup_key('foo.0.tar.gz'),
+            archive_backup_key('foo.1.tar.gz'))
+        self.assertEqual(
+            archive_backup_key('foo.0.tar.gz'),
+            archive_backup_key('foo.0.tar.gz'))
+        self.assertLess(
+            archive_backup_key('foo.1.tar.gz'),
+            archive_backup_key('foo.0.tar.gz'))
+        self.assertGreater(
+            archive_backup_key('foo.9.tar.gz'),
+            archive_backup_key('foo.10.tar.gz'))
 
-        # Not the same start for directories:
-        self.assertRaises(ValueError, strict_cmp_gzips,
-                          'foo.1.tar.gz', 'bar.1.tar.gz')
+        # tar or tar.gz are both accepted.
+        self.assertGreater(
+            archive_backup_key('foo.0.tar.gz'),
+            archive_backup_key('foo.1.tar'))
+        self.assertEqual(
+            archive_backup_key('foo.0.tar.gz'),
+            archive_backup_key('foo.0.tar'))
+        self.assertLess(
+            archive_backup_key('foo.1.tar.gz'),
+            archive_backup_key('foo.0.tar'))
+        self.assertGreater(
+            archive_backup_key('foo.9.tar.gz'),
+            archive_backup_key('foo.10.tar'))
 
-        # It shares most code with strict_cmp_backups,
+        # Compare timestamps.  Newest last.
+        self.assertLess(
+            archive_backup_key('foo.1999-12-31-23-59-30.tar'),
+            archive_backup_key('foo.2000-12-31-23-59-30.tar.gz'))
+
+        # You should only compare names with the same start,
+        # but that is not the job of the key.
+        self.assertEqual(
+            archive_backup_key('foo.1.tar'),
+            archive_backup_key('bar.1.tar'))
+
+        # It shares most code with backup_key,
         # so let's take over one more test from there.
         self.assertEqual(
             sorted([

--- a/src/collective/recipe/backup/tests/test_unit.py
+++ b/src/collective/recipe/backup/tests/test_unit.py
@@ -175,6 +175,7 @@ class CopyBlobsTestCase(unittest.TestCase):
 
     def test_strict_cmp_numbers(self):
         from collective.recipe.backup.copyblobs import strict_cmp_numbers
+        from collective.recipe.backup.copyblobs import number_key
         self.assertEqual(strict_cmp_numbers('0', '1'), -1)
         self.assertEqual(strict_cmp_numbers('0', '0'), 0)
         self.assertEqual(strict_cmp_numbers('1', '0'), 1)
@@ -199,15 +200,16 @@ class CopyBlobsTestCase(unittest.TestCase):
                                '1999-12-31-23-59-30'), 0)
 
         # Check the effect on a complete sort.
+        # We usually want it reversed.
         self.assertEqual(
-            sorted(['0', '2', '1'], cmp=strict_cmp_numbers),
+            sorted(['0', '2', '1'], key=number_key, reverse=True),
             ['0', '1', '2'])
         self.assertEqual(
             sorted([
                 '1999-12-31-23-59-30',
                 '2017-01-02-03-04-05',
                 '2017-10-02-03-04-05'],
-                cmp=strict_cmp_numbers),
+                key=number_key, reverse=True),
             [
                 '2017-10-02-03-04-05',
                 '2017-01-02-03-04-05',
@@ -218,21 +220,21 @@ class CopyBlobsTestCase(unittest.TestCase):
                 '2',
                 '1999-12-31-23-59-30',
                 '2017-01-02-03-04-05'],
-                cmp=strict_cmp_numbers),
+                key=number_key, reverse=True),
             [
                 '2017-01-02-03-04-05',
                 '1999-12-31-23-59-30',
                 '0',
                 '2'])
 
-        # Test reverse sorting for good measure.
+        # Test normal sorting for good measure.
         self.assertEqual(
             sorted([
                 '0',
                 '2',
                 '1999-12-31-23-59-30',
                 '2017-01-02-03-04-05'],
-                cmp=strict_cmp_numbers, reverse=True),
+                key=number_key),
             [
                 '2',
                 '0',
@@ -241,6 +243,7 @@ class CopyBlobsTestCase(unittest.TestCase):
 
     def test_strict_cmp_backups(self):
         from collective.recipe.backup.copyblobs import strict_cmp_backups
+        from collective.recipe.backup.copyblobs import backup_key
         self.assertEqual(strict_cmp_backups('foo.0', 'foo.1'), -1)
         self.assertEqual(strict_cmp_backups('foo.0', 'foo.0'), 0)
         self.assertEqual(strict_cmp_backups('foo.1', 'foo.0'), 1)
@@ -266,7 +269,7 @@ class CopyBlobsTestCase(unittest.TestCase):
                 'foo.2',
                 'foo.1999-12-31-23-59-30',
                 'foo.2017-01-02-03-04-05'],
-                cmp=strict_cmp_backups, reverse=True),
+                key=backup_key),
             [
                 'foo.2',
                 'foo.0',
@@ -275,6 +278,7 @@ class CopyBlobsTestCase(unittest.TestCase):
 
     def test_strict_cmp_gzips(self):
         from collective.recipe.backup.copyblobs import strict_cmp_gzips
+        from collective.recipe.backup.copyblobs import archive_backup_key
         self.assertEqual(strict_cmp_gzips('foo.0.tar.gz', 'foo.1.tar.gz'), -1)
         self.assertEqual(strict_cmp_gzips('foo.0.tar.gz', 'foo.0.tar.gz'), 0)
         self.assertEqual(strict_cmp_gzips('foo.1.tar.gz', 'foo.0.tar.gz'), 1)
@@ -292,7 +296,7 @@ class CopyBlobsTestCase(unittest.TestCase):
                 'foo.2.tar.gz',
                 'foo.1999-12-31-23-59-30.tar.gz',
                 'foo.2017-01-02-03-04-05.tar.gz'],
-                cmp=strict_cmp_gzips, reverse=True),
+                key=archive_backup_key),
             [
                 'foo.2.tar.gz',
                 'foo.0.tar.gz',

--- a/src/collective/recipe/backup/tests/zipbackup.rst
+++ b/src/collective/recipe/backup/tests/zipbackup.rst
@@ -21,7 +21,7 @@ Add mock ``bin/repozo`` script::
 
     >>> import sys
     >>> write('bin', 'repozo',
-    ...       "#!%s\nimport sys\nprint ' '.join(sys.argv[1:])" % sys.executable)
+    ...       "#!%s\nimport sys\nprint(' '.join(sys.argv[1:]))" % sys.executable)
     >>> dontcare = system('chmod u+x bin/repozo')
 
 Create directories and content::
@@ -45,7 +45,7 @@ Create some archived (gzipped) and not-archived separate backup scripts::
     ... keep = 42
     ... enable_zipbackup = true
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
     Generated script '/sample-buildout/bin/zipbackup'.
@@ -57,7 +57,7 @@ Create some archived (gzipped) and not-archived separate backup scripts::
 
 Now we test it::
 
-    >>> print system('bin/zipbackup')
+    >>> print(system('bin/zipbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups -F --gzip
     INFO: Created /sample-buildout/var/zipbackups
     INFO: Created /sample-buildout/var/blobstoragezips
@@ -68,7 +68,7 @@ Now we test it::
 
 Keep is ignored by zipbackup, always using 1 as value::
 
-    >>> print system('bin/zipbackup')
+    >>> print(system('bin/zipbackup'))
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups -F --gzip
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/zipbackups
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragezips
@@ -79,7 +79,7 @@ Keep is ignored by zipbackup, always using 1 as value::
 
 Now test the ziprestore script::
 
-    >>> print system('bin/ziprestore', input='yes\n')
+    >>> print(system('bin/ziprestore', input='yes\n'))
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups
     <BLANKLINE>
     This will replace the filestorage:
@@ -109,7 +109,7 @@ You can choose not to enable the zip scripts::
     ... keep = 42
     ... enable_zipbackup = false
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -139,7 +139,7 @@ the default::
     ... blob_storage = ${buildout:directory}/var/blobstorage
     ... keep = 42
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     Uninstalling backup.
     Installing backup.
     Generated script '/sample-buildout/bin/backup'.
@@ -168,7 +168,7 @@ refuse this combination::
     ... backup_blobs = false
     ... enable_zipbackup = true
     ... """)
-    >>> print system(buildout)
+    >>> print(system(buildout))
     While:
       Installing.
       Getting section backup.

--- a/src/collective/recipe/backup/utils.py
+++ b/src/collective/recipe/backup/utils.py
@@ -5,11 +5,24 @@ import shutil
 import subprocess
 import sys
 
+try:
+    from builtins import input as raw_input
+except ImportError:
+    # Python 2 has raw_input available by default.
+    pass
+
 
 logger = logging.getLogger('utils')
 
 # For zc.buildout's system() method:
 MUST_CLOSE_FDS = not sys.platform.startswith('win')
+
+try:
+    # Python 2
+    stringtypes = basestring
+except NameError:
+    # Python 3
+    stringtypes = str
 
 
 def system(command, input=''):


### PR DESCRIPTION
This adds basic Python 3 support. Biggest hurdle was switching from sorting with `cmp` to sorting with `key`.

When I try it locally, the tests on Python 3 fail for two reasons:

1. For some tests we use the `plone.recipe.zope2instance` recipe, and there is no Python 3 compatible version yet. Last year a [pull request](https://github.com/plone/plone.recipe.zope2instance/pull/25) was opened, but it is not finished yet.
2. The order of the output is different in Python 3. The order is actually better there: the print that we do in the dummy `bin/repozo` script is shown at the correct spot, instead of at the top:

```
File "/Users/maurits/community/collective.recipe.backup/src/collective/recipe/backup/tests/prefix.rst", line 75, in prefix.rst
Failed example:
    print(system('bin/restore', input='yes\n'))
Differences (ndiff with -expected +actual):
    - --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/backups
      <BLANKLINE>
      This will replace the filestorage:
          /sample-buildout/var/filestorage/Data.fs
    - Are you sure? (yes/No)?
    + Are you sure? (yes/No)? --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/backuplocation/backups
      INFO: Created directory /sample-buildout/var/filestorage
      INFO: Please wait while restoring database file: /sample-buildout/backuplocation/backups to /sample-buildout/var/filestorage/Data.fs
      <BLANKLINE>
```

So it is not really an option yet to enable Python 3 testing on Travis, because we know it will fail, but it *should* already work in practice. And Python 2 is still working fine.