### PR TITLE
Dropped official Python 2.6 support, added Python 3.7 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 sudo: false
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.6
+matrix:
+    include:
+        - python: "3.7"
+          dist: xenial
 cache:
   directories:
   - eggs
@@ -17,7 +20,3 @@ install:
 script:
   - bin/code-analysis
   - bin/test
-notifications:
-  irc:
-  email:
-    - maurits@vanrees.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 sudo: false
 language: python
+dist: xenial   # required for Python >= 3.7
 python:
-  - 2.7
-  - 3.6
-matrix:
-    include:
-        - python: "3.7"
-          dist: xenial
+  - "2.7"
+  - "3.6"
+  - "3.7"
 cache:
   directories:
   - eggs

--- a/news/49.feature
+++ b/news/49.feature
@@ -1,0 +1,3 @@
+Dropped official Python 2.6 support, added Python 3.7 support.
+No code change, but we are no longer testing 2.6.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(*rnames):
     return open(os.path.join(*rnames)).read()
 
 
-version = '4.0.2.dev0'
+version = '4.1.0.dev0'
 
 long_description = (
     read('README.rst')
@@ -47,10 +47,10 @@ setup(
         'Intended Audience :: System Administrators',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'License :: OSI Approved :: GNU General Public License (GPL)',


### PR DESCRIPTION
No code change, but we are no longer testing 2.6.  Fixes the rest of issue #49.
Bumped version to 4.1.0 for this.

Also, removed special notifications from .travis.yml.  The defaults are fine.
