### PR TITLE
Create symlink to latest blob timestamp

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -441,6 +441,7 @@ some system-wide directory like ``/var/zopebackups/instancename/`` and
     This option *requires* the ``blob_timestamps`` option to be true,
     because it needs the tarball names to be stable, instead of getting rotated.
     If you have explicitly set ``blob_timestamps`` to false, buildout will exit with an error.
+    Note that the ``latest`` symlink to the most recent backup is not created with ``incremental_blobs`` true.
     For large blobstorages it may take long to restore, so do test it out.
     But that is wise in all cases.
     Essentially, this feature seems to trade off storage space reduction with restore time.

--- a/README.rst
+++ b/README.rst
@@ -361,7 +361,7 @@ some system-wide directory like ``/var/zopebackups/instancename/`` and
     For example: ``blobstorage.1972-12-25-01-02-03``.
     Or with ``archive_blob = true``: ``blobstorage.1972-12-25-01-02-03.tar.gz``.
     Because the filename is unpredictable, since version 4.1 we create a ``latest`` symlink
-    the most recent backup.
+    to the most recent backup.
 
 ``blobbackuplocation``
     Directory where the blob storage will be backed up to.  Defaults

--- a/README.rst
+++ b/README.rst
@@ -360,6 +360,8 @@ some system-wide directory like ``/var/zopebackups/instancename/`` and
     They get a timestamp, the same timestamp that the ZODB filestorage backup gets.
     For example: ``blobstorage.1972-12-25-01-02-03``.
     Or with ``archive_blob = true``: ``blobstorage.1972-12-25-01-02-03.tar.gz``.
+    Because the filename is unpredictable, since version 4.1 we create a ``latest`` symlink
+    the most recent backup.
 
 ``blobbackuplocation``
     Directory where the blob storage will be backed up to.  Defaults

--- a/news/48.feature
+++ b/news/48.feature
@@ -1,0 +1,4 @@
+Create symlink to latest timestamped blobstorage backup.
+When ``blob_timestamps`` is false, ``blobstorage.0`` is a stable filename,
+but with ``blob_timestamps`` true, such a stable name was missing.
+[maurits]

--- a/src/collective/recipe/backup/copyblobs.py
+++ b/src/collective/recipe/backup/copyblobs.py
@@ -842,13 +842,19 @@ def backup_blobs(
                     "no database changes since last backup.",
                     dest,
                 )
-                # Now possibly remove old backups.
+                # Now possibly remove old backups and remove/create latest symlink.
+                if timestamps and not incremental_blobs:
+                    # Creating a symlink to the latest blob backup only makes sense in this combination.
+                    latest = dest
+                else:
+                    latest = None
                 cleanup(
                     destination,
                     full,
                     keep,
                     keep_blob_days,
                     fs_backup_location=fs_backup_location,
+                    latest=latest
                 )
                 return
         else:
@@ -897,9 +903,14 @@ def backup_blobs(
         dest = os.path.join(dest, base_name)
         logger.info("Copying %s to %s", source, dest)
         shutil.copytree(source, dest)
-    # Now possibly remove old backups.
+    # Now possibly remove old backups and remove/create latest symlink.
+    if timestamps and not incremental_blobs:
+        # Creating a symlink to the latest blob backup only makes sense in this combination.
+        latest = dest
+    else:
+        latest = None
     cleanup(
-        destination, full, keep, keep_blob_days, fs_backup_location=fs_backup_location
+        destination, full, keep, keep_blob_days, fs_backup_location=fs_backup_location, latest=latest
     )
 
 
@@ -950,9 +961,14 @@ def backup_blobs_archive(
                         "no database changes since last backup.",
                         dest,
                     )
-                    # Now possibly remove old backups.
+                    # Now possibly remove old backups and remove/create latest symlink.
+                    if timestamps and not incremental_blobs:
+                        # Creating a symlink to the latest blob backup only makes sense in this combination.
+                        latest = dest
+                    else:
+                        latest = None
                     cleanup_archives(
-                        destination, keep=keep, fs_backup_location=fs_backup_location
+                        destination, keep=keep, fs_backup_location=fs_backup_location, latest=latest
                     )
                     return
         else:
@@ -994,8 +1010,13 @@ def backup_blobs_archive(
         print(output)
     if failed:
         return
-    # Now possibly remove old backups.
-    cleanup_archives(destination, keep=keep, fs_backup_location=fs_backup_location)
+    # Now possibly remove old backups and remove/create latest symlink.
+    if timestamps and not incremental_blobs:
+        # Creating a symlink to the latest blob backup only makes sense in this combination.
+        latest = dest
+    else:
+        latest = None
+    cleanup_archives(destination, keep=keep, fs_backup_location=fs_backup_location, latest=latest)
 
 
 def is_full_tarball(path):
@@ -1446,7 +1467,7 @@ def remove_orphaned_blob_backups(backup_location, fs_backup_location, archive=Fa
 
 
 def cleanup(
-    backup_location, full=False, keep=0, keep_blob_days=0, fs_backup_location=None
+    backup_location, full=False, keep=0, keep_blob_days=0, fs_backup_location=None, latest=None
 ):
     """Clean up old blob backups.
 
@@ -1457,6 +1478,8 @@ def cleanup(
 
     For tests, see tests/cleanup_dir.rst.
     """
+    update_latest_symlink(backup_location, latest=latest)
+
     logger.debug("Starting cleanup of blob backups from %s", backup_location)
     if remove_orphaned_blob_backups(backup_location, fs_backup_location):
         # A True return value means there is nothing left to do.
@@ -1529,7 +1552,25 @@ def cleanup(
         )
 
 
-def cleanup_archives(backup_location, keep=0, fs_backup_location=None):
+def update_latest_symlink(backup_location, latest=None):
+    """Update symlink to latest blob backup."""
+    # Remove symlink to the latest blob backup.
+    cwd = os.getcwd()
+    os.chdir(backup_location)
+    symlink = "latest"
+    if os.path.islink(symlink):
+        logger.debug('Removed old symlink latest pointing to %s', os.path.realpath(symlink))
+        os.unlink(symlink)
+    if latest:
+        latest = os.path.basename(latest)
+        # This may recreate the symlink we previously removed, but okay.
+        logger.info('Creating symlink from latest to %s', latest)
+        os.symlink(latest, symlink)
+    # back to where we came from
+    os.chdir(cwd)
+
+
+def cleanup_archives(backup_location, keep=0, fs_backup_location=None, latest=None):
     """Clean up old blob backups.
 
     When fs_backup_location is passed and we find filestorage backups there,
@@ -1539,6 +1580,8 @@ def cleanup_archives(backup_location, keep=0, fs_backup_location=None):
 
     For tests, see tests/cleanup_archives.rst.
     """
+    update_latest_symlink(backup_location, latest=latest)
+
     logger.debug("Starting cleanup of blob archives from %s", backup_location)
     if remove_orphaned_blob_backups(backup_location, fs_backup_location, archive=True):
         # A True return value means there is nothing left to do.

--- a/src/collective/recipe/backup/copyblobs.py
+++ b/src/collective/recipe/backup/copyblobs.py
@@ -843,11 +843,11 @@ def backup_blobs(
                     dest,
                 )
                 # Now possibly remove old backups and remove/create latest symlink.
-                if timestamps and not incremental_blobs:
+                if incremental_blobs:
+                    latest = None
+                else:
                     # Creating a symlink to the latest blob backup only makes sense in this combination.
                     latest = dest
-                else:
-                    latest = None
                 cleanup(
                     destination,
                     full,

--- a/src/collective/recipe/backup/tests/backup_blobs_archive.rst
+++ b/src/collective/recipe/backup/tests/backup_blobs_archive.rst
@@ -52,6 +52,10 @@ Use timestamps with a fs_backup_location.
     -  blobs.1.tar.gz
     -  blobs.2.tar
     -  blobs.2017-05-24-11-54-39.tar.gz
+    l  latest
+    >>> import os
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobs.2017-05-24-11-54-39.tar.gz
 
 And again with the same settings, as I saw something go wrong once.
 
@@ -63,6 +67,7 @@ And again with the same settings, as I saw something go wrong once.
     -  blobs.1.tar.gz
     -  blobs.2.tar
     -  blobs.2017-05-24-11-54-39.tar.gz
+    l  latest
 
 Same without compressing, which accepts previous compressed tarballs too.
 
@@ -74,6 +79,7 @@ Same without compressing, which accepts previous compressed tarballs too.
     -  blobs.1.tar.gz
     -  blobs.2.tar
     -  blobs.2017-05-24-11-54-39.tar.gz
+    l  latest
 
 Same settings, now with a change and a newer filestorage backup.
 
@@ -87,6 +93,9 @@ Same settings, now with a change and a newer filestorage backup.
     -  blobs.2.tar
     -  blobs.2017-05-24-11-54-39.tar.gz
     -  blobs.2017-05-25-12-00-00.tar
+    l  latest
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobs.2017-05-25-12-00-00.tar
 
 Now with incremental_blobs, which requires timestamps to be True.
 

--- a/src/collective/recipe/backup/tests/backup_blobs_dir.rst
+++ b/src/collective/recipe/backup/tests/backup_blobs_dir.rst
@@ -92,7 +92,10 @@ Wait a while, so we get a different timestamp, and then change some stuff.
     >>> ls('backups')
     d  blobs.20...-...-...-...-...
     d  blobs.20...-...-...-...-...
-    >>> backup1 = sorted(os.listdir('backups'))[-1]
+    d  latest
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobs.20...-...-...-...-...
+    >>> backup1 = sorted(os.listdir('backups'))[1]
     >>> timestamp1 = backup1[len('blobs.'):]
     >>> timestamp0 < timestamp1
     True
@@ -114,8 +117,9 @@ to any filestorage backup.
     ...     fs_backup_location='fs')
     >>> ls('backups')
     d  blobs.20...-...-...-...-...
+    d  latest
     >>> len(sorted(os.listdir('backups')))  # The dots could shadow other backups.
-    1
+    2
     >>> backup1 == sorted(os.listdir('backups'))[0]
     True
     >>> ls('backups', backup1, 'blobs')
@@ -131,8 +135,11 @@ Pretend there is a newer filestorage backup and a blob change.
     >>> ls('backups')
     d  blobs.20...-...-...-...-...
     d  blobs.2100-01-01-00-00-00
+    d  latest
     >>> len(sorted(os.listdir('backups')))  # The dots could shadow a third backup
-    2
+    3
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobs.2100-01-01-00-00-00
     >>> ls('backups', 'blobs.2100-01-01-00-00-00', 'blobs')
     d  dir
     -  one.txt
@@ -157,8 +164,11 @@ Remove the oldest filestorage backup.
     ...    fs_backup_location='fs')
     >>> ls('backups')
     d  blobs.2100-01-01-00-00-00
+    d  latest
     >>> len(sorted(os.listdir('backups')))
-    1
+    2
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobs.2100-01-01-00-00-00
 
 Cleanup:
 

--- a/src/collective/recipe/backup/tests/blob_timestamps.rst
+++ b/src/collective/recipe/backup/tests/blob_timestamps.rst
@@ -578,12 +578,16 @@ Now we test it::
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/zipbackups
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragezips
     INFO: tar cf /sample-buildout/var/blobstoragezips/blobstorage.20...-...-...-...-...-....tar  -C /sample-buildout/var/blobstorage .
+    INFO: Creating symlink from latest to blobstorage.20...-...-...-...-...-....tar
     <BLANKLINE>
     >>> check_repozo_output()
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups -F --gzip
     >>> ls('var', 'blobstoragezips')
-    -   blobstorage.20...-...-...-...-...-....tar
+    -  blobstorage.20...-...-...-...-...-....tar
+    l  latest
     >>> zip_timestamp0 = sorted(os.listdir('var/blobstoragezips'))[0]
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobstorage.20...-...-...-...-...-....tar
 
 Keep is ignored by zipbackup, always using 1 as value.
 Pause a short time to avoid getting an error for overwriting the previous file::
@@ -593,15 +597,19 @@ Pause a short time to avoid getting an error for overwriting the previous file::
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/zipbackups
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragezips
     INFO: tar cf /sample-buildout/var/blobstoragezips/blobstorage.20...-...-...-...-...-....tar  -C /sample-buildout/var/blobstorage .
+    INFO: Creating symlink from latest to blobstorage.20...-...-...-...-...-....tar
     INFO: Removed 1 full blob backup, with 1 file. The latest 1 backup has been kept.
     <BLANKLINE>
     >>> check_repozo_output()
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups -F --gzip
     >>> ls('var', 'blobstoragezips')
-    -   blobstorage.20...-...-...-...-...-....tar
+    -  blobstorage.20...-...-...-...-...-....tar
+    l  latest
     >>> zip_timestamp1 = sorted(os.listdir('var/blobstoragezips'))[0]
     >>> zip_timestamp0 == zip_timestamp1
     False
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobstorage.20...-...-...-...-...-....tar
 
 Now test the ziprestore script::
 

--- a/src/collective/recipe/backup/tests/blob_timestamps.rst
+++ b/src/collective/recipe/backup/tests/blob_timestamps.rst
@@ -586,8 +586,10 @@ Now we test it::
     -  blobstorage.20...-...-...-...-...-....tar
     l  latest
     >>> zip_timestamp0 = sorted(os.listdir('var/blobstoragezips'))[0]
-    >>> print(os.path.realpath('backups/latest'))
-    /sample-buildout/backups/blobstorage.20...-...-...-...-...-....tar
+    >>> print(os.path.realpath('var/blobstoragezips/latest'))
+    /sample-buildout/var/blobstoragezips/blobstorage.20...-...-...-...-...-....tar
+    >>> os.path.realpath('var/blobstoragezips/latest').endswith(zip_timestamp0)
+    True
 
 Keep is ignored by zipbackup, always using 1 as value.
 Pause a short time to avoid getting an error for overwriting the previous file::
@@ -608,8 +610,10 @@ Pause a short time to avoid getting an error for overwriting the previous file::
     >>> zip_timestamp1 = sorted(os.listdir('var/blobstoragezips'))[0]
     >>> zip_timestamp0 == zip_timestamp1
     False
-    >>> print(os.path.realpath('backups/latest'))
-    /sample-buildout/backups/blobstorage.20...-...-...-...-...-....tar
+    >>> print(os.path.realpath('var/blobstoragezips/latest'))
+    /sample-buildout/var/blobstoragezips/blobstorage.20...-...-...-...-...-....tar
+    >>> os.path.realpath('var/blobstoragezips/latest').endswith(zip_timestamp1)
+    True
 
 Now test the ziprestore script::
 

--- a/src/collective/recipe/backup/tests/incremental_blobs.rst
+++ b/src/collective/recipe/backup/tests/incremental_blobs.rst
@@ -83,13 +83,17 @@ It is useless to use incremental blobs here: a snapshot is always one tarball.
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/snapshotbackups
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragesnapshots
     INFO: tar cf /sample-buildout/var/blobstoragesnapshots/blobstorage.20...-...-...-...-...-....tar  -C /sample-buildout/var/blobstorage .
+    INFO: Creating symlink from latest to blobstorage.20...-...-...-...-...-....tar
     <BLANKLINE>
     >>> check_repozo_output()
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
     >>> ls('var', 'blobstoragesnapshots')
     -  blobstorage.20...-...-...-...-...-....tar
+    l  latest
     >>> len(os.listdir('var/blobstoragesnapshots'))
-    1
+    2
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobstorage.20...-...-...-...-...-....tar
 
 We mock a file storage backup from 2016:
 

--- a/src/collective/recipe/backup/tests/incremental_blobs.rst
+++ b/src/collective/recipe/backup/tests/incremental_blobs.rst
@@ -92,8 +92,8 @@ It is useless to use incremental blobs here: a snapshot is always one tarball.
     l  latest
     >>> len(os.listdir('var/blobstoragesnapshots'))
     2
-    >>> print(os.path.realpath('backups/latest'))
-    /sample-buildout/backups/blobstorage.20...-...-...-...-...-....tar
+    >>> print(os.path.realpath('var/blobstoragesnapshots/latest'))
+    /sample-buildout/var/blobstoragesnapshots/blobstorage.20...-...-...-...-...-....tar
 
 We mock a file storage backup from 2016:
 


### PR DESCRIPTION
This implements feature request #48.

Note: ``incremental_blobs`` could be true, which can only be true when ``blob_timestamps`` is true. In that case there is no sane file that our ``latest`` symlink could point to: do you point to the latest full tarball or the latest delta? It seemed best to me to not create the symlink then.
