### PR TITLE
Use correct fs backup location when timestamping blob snapshots

### DIFF
--- a/news/55.bugfix
+++ b/news/55.bugfix
@@ -1,0 +1,2 @@
+When using timestamps, use correct filestorage backup location for blob timestamp of snapshot and zip backup.
+[maurits]

--- a/src/collective/recipe/backup/main.py
+++ b/src/collective/recipe/backup/main.py
@@ -88,8 +88,12 @@ def backup_main(
             )
         if only_blobs:
             fs_backup_location = None
-        else:
+        elif backup_method == config.STANDARD_BACKUP:
             fs_backup_location = storage["backup_location"]
+        elif backup_method == config.SNAPSHOT_BACKUP:
+            fs_backup_location = storage["snapshot_location"]
+        elif backup_method == config.ZIP_BACKUP:
+            fs_backup_location = storage["zip_location"]
         copyblobs.backup_blobs(
             blobdir,
             blob_backup_location,

--- a/src/collective/recipe/backup/tests/blob_timestamps.rst
+++ b/src/collective/recipe/backup/tests/blob_timestamps.rst
@@ -53,50 +53,69 @@ Write a buildout config::
     >>> mkdir('var', 'blobstorage-bar')
     >>> write('var', 'blobstorage-bar', 'blob-bar1.txt', 'Sample blob bar 1.')
 
+Mock some repozo backups with timestamps.
+In this way we can check that our logic for matching a blobstorage backup and filestorage backup works.
+And it is easier to write the tests with a real date rather than 20...-...-...-...-...-...
+
+    >>> mkdir('var', 'snapshotbackups_foo')
+    >>> mkdir('var', 'snapshotbackups_bar')
+    >>> mkdir('var', 'snapshotbackups')
+    >>> write('var', 'snapshotbackups_foo', '1999-12-31-01-01-01.fsz', 'mock datafs backup')
+    >>> write('var', 'snapshotbackups_bar', '1999-12-31-01-01-02.fsz', 'mock datafs backup')
+    >>> write('var', 'snapshotbackups', '1999-12-31-01-01-03.fsz', 'mock datafs backup')
+
 Test the snapshotbackup first, as that should be easiest.
 
     >>> print(system('bin/snapshotbackup'))
-    INFO: Created /sample-buildout/var/snapshotbackups_foo
     INFO: Created /sample-buildout/var/blobstoragesnapshots_foo
-    INFO: Created /sample-buildout/var/snapshotbackups_bar
     INFO: Created /sample-buildout/var/blobstoragesnapshots_bar
-    INFO: Created /sample-buildout/var/snapshotbackups
     INFO: Created /sample-buildout/var/blobstoragesnapshots
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/foo.fs to /sample-buildout/var/snapshotbackups_foo
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/bar.fs to /sample-buildout/var/snapshotbackups_bar
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/snapshotbackups
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage-foo to /sample-buildout/var/blobstoragesnapshots_foo
-    INFO: rsync -a  /sample-buildout/var/blobstorage-foo /sample-buildout/var/blobstoragesnapshots_foo/blobstorage-foo.20...
+    INFO: rsync -a  /sample-buildout/var/blobstorage-foo /sample-buildout/var/blobstoragesnapshots_foo/blobstorage-foo.1999-12-31-01-01-01
+    INFO: Creating symlink from latest to blobstorage-foo.1999-12-31-01-01-01
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage-bar to /sample-buildout/var/blobstoragesnapshots_bar
-    INFO: rsync -a  /sample-buildout/var/blobstorage-bar /sample-buildout/var/blobstoragesnapshots_bar/blobstorage-bar.20...
+    INFO: rsync -a  /sample-buildout/var/blobstorage-bar /sample-buildout/var/blobstoragesnapshots_bar/blobstorage-bar.1999-12-31-01-01-02
+    INFO: Creating symlink from latest to blobstorage-bar.1999-12-31-01-01-02
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragesnapshots
-    INFO: rsync -a  /sample-buildout/var/blobstorage /sample-buildout/var/blobstoragesnapshots/blobstorage.20...-...-...-...-...-...
+    INFO: rsync -a  /sample-buildout/var/blobstorage /sample-buildout/var/blobstoragesnapshots/blobstorage.1999-12-31-01-01-03
+    INFO: Creating symlink from latest to blobstorage.1999-12-31-01-01-03
     <BLANKLINE>
     >>> check_repozo_output()
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -F --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -F --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
     >>> ls('var', 'blobstoragesnapshots')
-    d  blobstorage.20...-...-...-...-...-...
-    >>> timestamp0 = sorted(os.listdir('var/blobstoragesnapshots/'))[0]
+    d  blobstorage.1999-12-31-01-01-03
+    d  latest
+    >>> timestamp0 = 'blobstorage.1999-12-31-01-01-03'
     >>> ls('var', 'blobstoragesnapshots', timestamp0)
     d  blobstorage
     >>> ls('var', 'blobstoragesnapshots_foo')
-    d  blobstorage-foo.20...-...-...-...-...-...
-    >>> foo_timestamp0 = sorted(os.listdir('var/blobstoragesnapshots_foo/'))[0]
+    d  blobstorage-foo.1999-12-31-01-01-01
+    d  latest
+    >>> foo_timestamp0 = 'blobstorage-foo.1999-12-31-01-01-01'
     >>> ls('var', 'blobstoragesnapshots_foo', foo_timestamp0)
     d  blobstorage-foo
     >>> ls('var', 'blobstoragesnapshots_bar')
-    d  blobstorage-bar.20...-...-...-...-...-...
-    >>> bar_timestamp0 = sorted(os.listdir('var/blobstoragesnapshots_bar/'))[0]
+    d  blobstorage-bar.1999-12-31-01-01-02
+    d  latest
+    >>> bar_timestamp0 = 'blobstorage-bar.1999-12-31-01-01-02'
     >>> ls('var', 'blobstoragesnapshots_bar', bar_timestamp0)
     d  blobstorage-bar
 
-Let's try that some more, with some time in between so we can more easily test restoring to a specific time later.
+Let's try that some more, with a new batch of mock Data.fs backups and extra blob files.
+Then we can more easily test restoring to a specific time later.
 Note that due to the timestamps no renaming takes place from blobstorage.0 to blobstorage.1.
+We sleep a bit, because I sometimes get slightly different test results.
 
     >>> import time
-    >>> time.sleep(2)
+    >>> time.sleep(1)
+    >>> write('var', 'snapshotbackups_foo', '1999-12-31-01-02-01.fsz', 'mock datafs backup')
+    >>> write('var', 'snapshotbackups_bar', '1999-12-31-01-02-02.fsz', 'mock datafs backup')
+    >>> write('var', 'snapshotbackups', '1999-12-31-01-02-03.fsz', 'mock datafs backup')
     >>> write('var', 'blobstorage', 'blob2.txt', 'Sample blob 2.')
     >>> write('var', 'blobstorage-foo', 'blob-foo2.txt', 'Sample blob foo 2.')
     >>> write('var', 'blobstorage-bar', 'blob-bar2.txt', 'Sample blob bar 2.')
@@ -105,22 +124,24 @@ Note that due to the timestamps no renaming takes place from blobstorage.0 to bl
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/bar.fs to /sample-buildout/var/snapshotbackups_bar
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/snapshotbackups
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage-foo to /sample-buildout/var/blobstoragesnapshots_foo
-    INFO: rsync -a  --delete --link-dest=../blobstorage-foo.20...-...-...-...-...-... /sample-buildout/var/blobstorage-foo /sample-buildout/var/blobstoragesnapshots_foo/blobstorage-foo.20...-...-...-...-...-...
+    INFO: rsync -a  --delete --link-dest=../blobstorage-foo.1999-12-31-01-01-01 /sample-buildout/var/blobstorage-foo /sample-buildout/var/blobstoragesnapshots_foo/blobstorage-foo.1999-12-31-01-02-01
+    INFO: Creating symlink from latest to blobstorage-foo.1999-12-31-01-02-01
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage-bar to /sample-buildout/var/blobstoragesnapshots_bar
-    INFO: rsync -a  --delete --link-dest=../blobstorage-bar.20...-...-...-...-...-... /sample-buildout/var/blobstorage-bar /sample-buildout/var/blobstoragesnapshots_bar/blobstorage-bar.20...-...-...-...-...-...
+    INFO: rsync -a  --delete --link-dest=../blobstorage-bar.1999-12-31-01-01-02 /sample-buildout/var/blobstorage-bar /sample-buildout/var/blobstoragesnapshots_bar/blobstorage-bar.1999-12-31-01-02-02
+    INFO: Creating symlink from latest to blobstorage-bar.1999-12-31-01-02-02
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragesnapshots
-    INFO: rsync -a  --delete --link-dest=../blobstorage.20...-...-...-...-...-... /sample-buildout/var/blobstorage /sample-buildout/var/blobstoragesnapshots/blobstorage.20...-...-...-...-...-...
+    INFO: rsync -a  --delete --link-dest=../blobstorage.1999-12-31-01-01-03 /sample-buildout/var/blobstorage /sample-buildout/var/blobstoragesnapshots/blobstorage.1999-12-31-01-02-03
+    INFO: Creating symlink from latest to blobstorage.1999-12-31-01-02-03
     <BLANKLINE>
     >>> check_repozo_output()
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -F --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -F --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
     >>> ls('var/blobstoragesnapshots')
-    d  blobstorage.20...-...-...-...-...-...
-    d  blobstorage.20...-...-...-...-...-...
-    >>> timestamp0 == sorted(os.listdir('var/blobstoragesnapshots/'))[0]
-    True
-    >>> timestamp1 = sorted(os.listdir('var/blobstoragesnapshots/'))[1]
+    d  blobstorage.1999-12-31-01-01-03
+    d  blobstorage.1999-12-31-01-02-03
+    d  latest
+    >>> timestamp1 = 'blobstorage.1999-12-31-01-02-03'
     >>> ls('var', 'blobstoragesnapshots', timestamp1, 'blobstorage')
     -  blob1.txt
     -  blob2.txt
@@ -133,11 +154,10 @@ Note that due to the timestamps no renaming takes place from blobstorage.0 to bl
     >>> cat('var', 'blobstoragesnapshots', timestamp0, 'blobstorage', 'blob1.txt')
     Sample blob 1.
     >>> ls('var', 'blobstoragesnapshots_foo')
-    d  blobstorage-foo.20...-...-...-...-...-...
-    d  blobstorage-foo.20...-...-...-...-...-...
-    >>> foo_timestamp0 == sorted(os.listdir('var/blobstoragesnapshots_foo/'))[0]
-    True
-    >>> foo_timestamp1 = sorted(os.listdir('var/blobstoragesnapshots_foo/'))[1]
+    d  blobstorage-foo.1999-12-31-01-01-01
+    d  blobstorage-foo.1999-12-31-01-02-01
+    d  latest
+    >>> foo_timestamp1 = 'blobstorage-foo.1999-12-31-01-02-01'
     >>> ls('var', 'blobstoragesnapshots_foo', foo_timestamp1, 'blobstorage-foo')
     -  blob-foo1.txt
     -  blob-foo2.txt
@@ -154,7 +174,10 @@ Now remove an item and change an item.
 Actually, files in blobstorage are not expected to change ever.
 But let's test it for good measure::
 
-    >>> time.sleep(2)
+    >>> time.sleep(1)
+    >>> write('var', 'snapshotbackups_foo', '1999-12-31-01-03-01.fsz', 'mock datafs backup')
+    >>> write('var', 'snapshotbackups_bar', '1999-12-31-01-03-02.fsz', 'mock datafs backup')
+    >>> write('var', 'snapshotbackups', '1999-12-31-01-03-03.fsz', 'mock datafs backup')
     >>> remove('var', 'blobstorage', 'blob2.txt')
     >>> remove('var', 'blobstorage-foo', 'blob-foo1.txt')
     >>> remove('var', 'blobstorage-bar', 'blob-bar1.txt')
@@ -164,25 +187,25 @@ But let's test it for good measure::
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/bar.fs to /sample-buildout/var/snapshotbackups_bar
     INFO: Please wait while making snapshot backup: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/snapshotbackups
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage-foo to /sample-buildout/var/blobstoragesnapshots_foo
-    INFO: rsync -a  --delete --link-dest=../blobstorage-foo.20...-...-...-...-...-... /sample-buildout/var/blobstorage-foo /sample-buildout/var/blobstoragesnapshots_foo/blobstorage-foo.20...-...-...-...-...-...
+    INFO: rsync -a  --delete --link-dest=../blobstorage-foo.1999-12-31-01-02-01 /sample-buildout/var/blobstorage-foo /sample-buildout/var/blobstoragesnapshots_foo/blobstorage-foo.1999-12-31-01-03-01
+    INFO: Creating symlink from latest to blobstorage-foo.1999-12-31-01-03-01
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage-bar to /sample-buildout/var/blobstoragesnapshots_bar
-    INFO: rsync -a  --delete --link-dest=../blobstorage-bar.20...-...-...-...-...-... /sample-buildout/var/blobstorage-bar /sample-buildout/var/blobstoragesnapshots_bar/blobstorage-bar.20...-...-...-...-...-...
+    INFO: rsync -a  --delete --link-dest=../blobstorage-bar.1999-12-31-01-02-02 /sample-buildout/var/blobstorage-bar /sample-buildout/var/blobstoragesnapshots_bar/blobstorage-bar.1999-12-31-01-03-02
+    INFO: Creating symlink from latest to blobstorage-bar.1999-12-31-01-03-02
     INFO: Please wait while making snapshot of blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragesnapshots
-    INFO: rsync -a  --delete --link-dest=../blobstorage.20...-...-...-...-...-... /sample-buildout/var/blobstorage /sample-buildout/var/blobstoragesnapshots/blobstorage.20...-...-...-...-...-...
+    INFO: rsync -a  --delete --link-dest=../blobstorage.1999-12-31-01-02-03 /sample-buildout/var/blobstorage /sample-buildout/var/blobstoragesnapshots/blobstorage.1999-12-31-01-03-03
+    INFO: Creating symlink from latest to blobstorage.1999-12-31-01-03-03
     <BLANKLINE>
     >>> check_repozo_output()
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -F --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -F --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -F --gzip
     >>> ls('var/blobstoragesnapshots')
-    d  blobstorage.20...-...-...-...-...-...
-    d  blobstorage.20...-...-...-...-...-...
-    d  blobstorage.20...-...-...-...-...-...
-    >>> timestamp0 == sorted(os.listdir('var/blobstoragesnapshots/'))[0]
-    True
-    >>> timestamp1 == sorted(os.listdir('var/blobstoragesnapshots/'))[1]
-    True
-    >>> timestamp2 = sorted(os.listdir('var/blobstoragesnapshots/'))[2]
+    d  blobstorage.1999-12-31-01-01-03
+    d  blobstorage.1999-12-31-01-02-03
+    d  blobstorage.1999-12-31-01-03-03
+    d  latest
+    >>> timestamp2 = 'blobstorage.1999-12-31-01-03-03'
     >>> ls('var', 'blobstoragesnapshots', timestamp2, 'blobstorage')
     -  blob1.txt
     >>> ls('var', 'blobstoragesnapshots', timestamp1, 'blobstorage')
@@ -197,14 +220,11 @@ But let's test it for good measure::
     >>> cat('var', 'blobstoragesnapshots', timestamp0, 'blobstorage', 'blob1.txt')
     Sample blob 1.
     >>> ls('var', 'blobstoragesnapshots_foo')
-    d  blobstorage-foo.20...-...-...-...-...-...
-    d  blobstorage-foo.20...-...-...-...-...-...
-    d  blobstorage-foo.20...-...-...-...-...-...
-    >>> foo_timestamp0 == sorted(os.listdir('var/blobstoragesnapshots_foo/'))[0]
-    True
-    >>> foo_timestamp1 == sorted(os.listdir('var/blobstoragesnapshots_foo/'))[1]
-    True
-    >>> foo_timestamp2 = sorted(os.listdir('var/blobstoragesnapshots_foo/'))[2]
+    d  blobstorage-foo.1999-12-31-01-01-01
+    d  blobstorage-foo.1999-12-31-01-02-01
+    d  blobstorage-foo.1999-12-31-01-03-01
+    d  latest
+    >>> foo_timestamp2 = 'blobstorage-foo.1999-12-31-01-03-01'
     >>> ls('var', 'blobstoragesnapshots_foo', foo_timestamp2, 'blobstorage-foo')
     -  blob-foo2.txt
     >>> ls('var', 'blobstoragesnapshots_foo', foo_timestamp1, 'blobstorage-foo')
@@ -221,47 +241,60 @@ sure if this works on all operating systems.
     >>> stat_0.st_ino == stat_1.st_ino
     True
 
-Let's see how a bin/backup goes:
+Let's see how a bin/backup goes.
+Again mock some repozo backups with timestamps.
 
+    >>> time.sleep(1)
+    >>> mkdir('var', 'backups_foo')
+    >>> mkdir('var', 'backups_bar')
+    >>> mkdir('var', 'backups')
+    >>> write('var', 'backups_foo', '1999-12-31-02-01-01.fsz', 'mock datafs backup')
+    >>> write('var', 'backups_bar', '1999-12-31-02-01-02.fsz', 'mock datafs backup')
+    >>> write('var', 'backups', '1999-12-31-02-01-03.fsz', 'mock datafs backup')
     >>> print(system('bin/backup'))
-    INFO: Created /sample-buildout/var/backups_foo
     INFO: Created /sample-buildout/var/blobstoragebackups_foo
-    INFO: Created /sample-buildout/var/backups_bar
     INFO: Created /sample-buildout/var/blobstoragebackups_bar
-    INFO: Created /sample-buildout/var/backups
     INFO: Created /sample-buildout/var/blobstoragebackups
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/foo.fs to /sample-buildout/var/backups_foo
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/bar.fs to /sample-buildout/var/backups_bar
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/backups
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage-foo to /sample-buildout/var/blobstoragebackups_foo
-    INFO: rsync -a  /sample-buildout/var/blobstorage-foo /sample-buildout/var/blobstoragebackups_foo/blobstorage-foo.20...-...-...-...-...-...
+    INFO: rsync -a  /sample-buildout/var/blobstorage-foo /sample-buildout/var/blobstoragebackups_foo/blobstorage-foo.1999-12-31-02-01-01
+    INFO: Creating symlink from latest to blobstorage-foo.1999-12-31-02-01-01
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage-bar to /sample-buildout/var/blobstoragebackups_bar
-    INFO: rsync -a  /sample-buildout/var/blobstorage-bar /sample-buildout/var/blobstoragebackups_bar/blobstorage-bar.20...-...-...-...-...-...
+    INFO: rsync -a  /sample-buildout/var/blobstorage-bar /sample-buildout/var/blobstoragebackups_bar/blobstorage-bar.1999-12-31-02-01-02
+    INFO: Creating symlink from latest to blobstorage-bar.1999-12-31-02-01-02
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragebackups
-    INFO: rsync -a  /sample-buildout/var/blobstorage /sample-buildout/var/blobstoragebackups/blobstorage.20...-...-...-...-...-...
+    INFO: rsync -a  /sample-buildout/var/blobstorage /sample-buildout/var/blobstoragebackups/blobstorage.1999-12-31-02-01-03
+    INFO: Creating symlink from latest to blobstorage.1999-12-31-02-01-03
     <BLANKLINE>
     >>> check_repozo_output()
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo --quick --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar --quick --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
-    >>> backup_timestamp0 = sorted(os.listdir('var/blobstoragebackups/'))[0]
+    >>> backup_timestamp0 = 'blobstorage.1999-12-31-02-01-03'
     >>> ls('var', 'blobstoragebackups')
-    d  blobstorage.20...-...-...-...-...-...
+    d  blobstorage.1999-12-31-02-01-03
+    d  latest
     >>> ls('var', 'blobstoragebackups', backup_timestamp0)
     d  blobstorage
     >>> ls('var', 'blobstoragebackups', backup_timestamp0, 'blobstorage')
     -  blob1.txt
-    >>> foo_backup_timestamp0 = sorted(os.listdir('var/blobstoragebackups_foo/'))[0]
+    >>> foo_backup_timestamp0 = 'blobstorage-foo.1999-12-31-02-01-01'
     >>> ls('var', 'blobstoragebackups_foo')
-    d  blobstorage-foo.20...-...-...-...-...-...
+    d  blobstorage-foo.1999-12-31-02-01-01
+    d  latest
     >>> ls('var', 'blobstoragebackups_foo', foo_backup_timestamp0)
     d  blobstorage-foo
     >>> ls('var', 'blobstoragebackups_foo', foo_backup_timestamp0, 'blobstorage-foo')
     -  blob-foo2.txt
 
-We try again with an extra 'blob' and a changed 'blob':
+We try again with an extra 'blob' and a changed 'blob', and a new filestorage backup:
 
-    >>> time.sleep(2)
+    >>> time.sleep(1)
+    >>> write('var', 'backups_foo', '1999-12-31-02-02-01.fsz', 'mock datafs backup')
+    >>> write('var', 'backups_bar', '1999-12-31-02-02-02.fsz', 'mock datafs backup')
+    >>> write('var', 'backups', '1999-12-31-02-02-03.fsz', 'mock datafs backup')
     >>> write('var', 'blobstorage', 'blob2.txt', 'Sample blob 2.')
     >>> write('var', 'blobstorage', 'blob1.txt', 'Sample blob 1 version 3.')
     >>> print(system('bin/backup'))
@@ -269,22 +302,24 @@ We try again with an extra 'blob' and a changed 'blob':
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/bar.fs to /sample-buildout/var/backups_bar
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/backups
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage-foo to /sample-buildout/var/blobstoragebackups_foo
-    INFO: rsync -a  --delete --link-dest=../blobstorage-foo.20...-...-...-...-...-... /sample-buildout/var/blobstorage-foo /sample-buildout/var/blobstoragebackups_foo/blobstorage-foo.20...-...-...-...-...-...
+    INFO: rsync -a  --delete --link-dest=../blobstorage-foo.1999-12-31-02-01-01 /sample-buildout/var/blobstorage-foo /sample-buildout/var/blobstoragebackups_foo/blobstorage-foo.1999-12-31-02-02-01
+    INFO: Creating symlink from latest to blobstorage-foo.1999-12-31-02-02-01
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage-bar to /sample-buildout/var/blobstoragebackups_bar
-    INFO: rsync -a  --delete --link-dest=../blobstorage-bar.20...-...-...-...-...-... /sample-buildout/var/blobstorage-bar /sample-buildout/var/blobstoragebackups_bar/blobstorage-bar.20...-...-...-...-...-...
+    INFO: rsync -a  --delete --link-dest=../blobstorage-bar.1999-12-31-02-01-02 /sample-buildout/var/blobstorage-bar /sample-buildout/var/blobstoragebackups_bar/blobstorage-bar.1999-12-31-02-02-02
+    INFO: Creating symlink from latest to blobstorage-bar.1999-12-31-02-02-02
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragebackups
-    INFO: rsync -a  --delete --link-dest=../blobstorage.20...-...-...-...-...-... /sample-buildout/var/blobstorage /sample-buildout/var/blobstoragebackups/blobstorage.20...-...-...-...-...-...
+    INFO: rsync -a  --delete --link-dest=../blobstorage.1999-12-31-02-01-03 /sample-buildout/var/blobstorage /sample-buildout/var/blobstoragebackups/blobstorage.1999-12-31-02-02-03
+    INFO: Creating symlink from latest to blobstorage.1999-12-31-02-02-03
     <BLANKLINE>
     >>> check_repozo_output()
     --backup -f /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo --quick --gzip
     --backup -f /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/backups_bar --quick --gzip
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/backups --quick --gzip
     >>> ls('var', 'blobstoragebackups')
-    d  blobstorage.20...-...-...-...-...-...
-    d  blobstorage.20...-...-...-...-...-...
-    >>> backup_timestamp0 == sorted(os.listdir('var/blobstoragebackups/'))[0]
-    True
-    >>> backup_timestamp1 = sorted(os.listdir('var/blobstoragebackups/'))[1]
+    d  blobstorage.1999-12-31-02-01-03
+    d  blobstorage.1999-12-31-02-02-03
+    d  latest
+    >>> backup_timestamp1 = 'blobstorage.1999-12-31-02-02-03'
     >>> ls('var', 'blobstoragebackups', backup_timestamp1, 'blobstorage')
     -  blob1.txt
     -  blob2.txt
@@ -338,11 +373,11 @@ The third file should be gone afterwards::
     INFO: Please wait while restoring database file: /sample-buildout/var/backups_bar to /sample-buildout/var/filestorage/bar.fs
     INFO: Please wait while restoring database file: /sample-buildout/var/backups to /sample-buildout/var/filestorage/Data.fs
     INFO: Restoring blobs from /sample-buildout/var/blobstoragebackups_foo to /sample-buildout/var/blobstorage-foo
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_foo/blobstorage-foo.20...-...-...-...-...-.../blobstorage-foo /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_foo/blobstorage-foo.1999-12-31-02-02-01/blobstorage-foo /sample-buildout/var
     INFO: Restoring blobs from /sample-buildout/var/blobstoragebackups_bar to /sample-buildout/var/blobstorage-bar
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_bar/blobstorage-bar.20...-...-...-...-...-.../blobstorage-bar /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_bar/blobstorage-bar.1999-12-31-02-02-02/blobstorage-bar /sample-buildout/var
     INFO: Restoring blobs from /sample-buildout/var/blobstoragebackups to /sample-buildout/var/blobstorage
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups/blobstorage.20...-...-...-...-...-.../blobstorage /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups/blobstorage.1999-12-31-02-02-03/blobstorage /sample-buildout/var
     <BLANKLINE>
     >>> check_repozo_output()
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo
@@ -367,11 +402,11 @@ With the ``no-prompt`` option we avoid the question::
     INFO: Please wait while restoring database file: /sample-buildout/var/backups_bar to /sample-buildout/var/filestorage/bar.fs
     INFO: Please wait while restoring database file: /sample-buildout/var/backups to /sample-buildout/var/filestorage/Data.fs
     INFO: Restoring blobs from /sample-buildout/var/blobstoragebackups_foo to /sample-buildout/var/blobstorage-foo
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_foo/blobstorage-foo.20...-...-...-...-...-.../blobstorage-foo /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_foo/blobstorage-foo.1999-12-31-02-02-01/blobstorage-foo /sample-buildout/var
     INFO: Restoring blobs from /sample-buildout/var/blobstoragebackups_bar to /sample-buildout/var/blobstorage-bar
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_bar/blobstorage-bar.20...-...-...-...-...-.../blobstorage-bar /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_bar/blobstorage-bar.1999-12-31-02-02-02/blobstorage-bar /sample-buildout/var
     INFO: Restoring blobs from /sample-buildout/var/blobstoragebackups to /sample-buildout/var/blobstorage
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups/blobstorage.20...-...-...-...-...-.../blobstorage /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups/blobstorage.1999-12-31-02-02-03/blobstorage /sample-buildout/var
     <BLANKLINE>
     >>> check_repozo_output()
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo
@@ -389,11 +424,8 @@ Since we use timestamps, this should be fairly straight forward.
     >>> backup_timestamp0 < backup_timestamp1
     True
     >>> backup_timestamp0
-    'blobstorage.20...-...-...-...-...-...'
-    >>> time_string = backup_timestamp0[len('blobstorage.'):]
-    >>> time_string
-    '20...-...-...-...-...-...'
-    >>> print(system('bin/restore %s' % time_string, input='yes\n'))
+    'blobstorage.1999-12-31-02-01-03'
+    >>> print(system('bin/restore 1999-12-31-02-01-03', input='yes\n'))
     <BLANKLINE>
     This will replace the filestorage:
         /sample-buildout/var/filestorage/foo.fs
@@ -409,11 +441,11 @@ Since we use timestamps, this should be fairly straight forward.
     INFO: Please wait while restoring database file: /sample-buildout/var/backups_bar to /sample-buildout/var/filestorage/bar.fs
     INFO: Please wait while restoring database file: /sample-buildout/var/backups to /sample-buildout/var/filestorage/Data.fs
     INFO: Restoring blobs from /sample-buildout/var/blobstoragebackups_foo to /sample-buildout/var/blobstorage-foo
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_foo/blobstorage-foo.20...-...-...-...-...-.../blobstorage-foo /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_foo/blobstorage-foo.1999-12-31-02-01-01/blobstorage-foo /sample-buildout/var
     INFO: Restoring blobs from /sample-buildout/var/blobstoragebackups_bar to /sample-buildout/var/blobstorage-bar
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_bar/blobstorage-bar.20...-...-...-...-...-.../blobstorage-bar /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups_bar/blobstorage-bar.1999-12-31-02-01-02/blobstorage-bar /sample-buildout/var
     INFO: Restoring blobs from /sample-buildout/var/blobstoragebackups to /sample-buildout/var/blobstorage
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups/blobstorage.20...-...-...-...-...-.../blobstorage /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragebackups/blobstorage.1999-12-31-02-01-03/blobstorage /sample-buildout/var
     <BLANKLINE>
     >>> check_repozo_output()
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/backups_foo -D ...
@@ -447,11 +479,11 @@ The snapshotrestore works too::
     INFO: Please wait while restoring database file: /sample-buildout/var/snapshotbackups_bar to /sample-buildout/var/filestorage/bar.fs
     INFO: Please wait while restoring database file: /sample-buildout/var/snapshotbackups to /sample-buildout/var/filestorage/Data.fs
     INFO: Restoring blobs from /sample-buildout/var/blobstoragesnapshots_foo to /sample-buildout/var/blobstorage-foo
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots_foo/blobstorage-foo.20...-...-...-...-...-.../blobstorage-foo /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots_foo/blobstorage-foo.1999-12-31-01-03-01/blobstorage-foo /sample-buildout/var
     INFO: Restoring blobs from /sample-buildout/var/blobstoragesnapshots_bar to /sample-buildout/var/blobstorage-bar
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots_bar/blobstorage-bar.20...-...-...-...-...-.../blobstorage-bar /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots_bar/blobstorage-bar.1999-12-31-01-03-02/blobstorage-bar /sample-buildout/var
     INFO: Restoring blobs from /sample-buildout/var/blobstoragesnapshots to /sample-buildout/var/blobstorage
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots/blobstorage.20...-...-...-...-...-.../blobstorage /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots/blobstorage.1999-12-31-01-03-03/blobstorage /sample-buildout/var
     <BLANKLINE>
     >>> check_repozo_output()
     --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo
@@ -463,9 +495,10 @@ Check that this fits what is in the most recent snapshot::
     >>> ls('var/blobstorage')
     -  blob1.txt
     >>> ls('var/blobstoragesnapshots')
-    d  blobstorage.20...-...-...-...-...-...
-    d  blobstorage.20...-...-...-...-...-...
-    d  blobstorage.20...-...-...-...-...-...
+    d  blobstorage.1999-12-31-01-01-03
+    d  blobstorage.1999-12-31-01-02-03
+    d  blobstorage.1999-12-31-01-03-03
+    d  latest
     >>> ls('var', 'blobstoragesnapshots', timestamp2, 'blobstorage')
     -  blob1.txt
     >>> ls('var', 'blobstoragesnapshots', timestamp1, 'blobstorage')
@@ -489,11 +522,8 @@ Since we use timestamps, this should be fairly straight forward.
     >>> timestamp0 < timestamp1 < timestamp2
     True
     >>> timestamp1
-    'blobstorage.20...-...-...-...-...-...'
-    >>> time_string = timestamp1[len('blobstorage.'):]
-    >>> time_string
-    '20...-...-...-...-...-...'
-    >>> print(system('bin/snapshotrestore %s' % time_string, input='yes\n'))
+    'blobstorage.1999-12-31-01-02-03'
+    >>> print(system('bin/snapshotrestore 1999-12-31-01-02-03', input='yes\n'))
     <BLANKLINE>
     This will replace the filestorage:
         /sample-buildout/var/filestorage/foo.fs
@@ -509,16 +539,16 @@ Since we use timestamps, this should be fairly straight forward.
     INFO: Please wait while restoring database file: /sample-buildout/var/snapshotbackups_bar to /sample-buildout/var/filestorage/bar.fs
     INFO: Please wait while restoring database file: /sample-buildout/var/snapshotbackups to /sample-buildout/var/filestorage/Data.fs
     INFO: Restoring blobs from /sample-buildout/var/blobstoragesnapshots_foo to /sample-buildout/var/blobstorage-foo
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots_foo/blobstorage-foo.20...-...-...-...-...-.../blobstorage-foo /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots_foo/blobstorage-foo.1999-12-31-01-02-01/blobstorage-foo /sample-buildout/var
     INFO: Restoring blobs from /sample-buildout/var/blobstoragesnapshots_bar to /sample-buildout/var/blobstorage-bar
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots_bar/blobstorage-bar.20...-...-...-...-...-.../blobstorage-bar /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots_bar/blobstorage-bar.1999-12-31-01-02-02/blobstorage-bar /sample-buildout/var
     INFO: Restoring blobs from /sample-buildout/var/blobstoragesnapshots to /sample-buildout/var/blobstorage
-    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots/blobstorage.20...-...-...-...-...-.../blobstorage /sample-buildout/var
+    INFO: rsync -a  --delete /sample-buildout/var/blobstoragesnapshots/blobstorage.1999-12-31-01-02-03/blobstorage /sample-buildout/var
     <BLANKLINE>
     >>> check_repozo_output()
-    --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -D ...
-    --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -D ...
-    --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -D ...
+    --recover -o /sample-buildout/var/filestorage/foo.fs -r /sample-buildout/var/snapshotbackups_foo -D 1999-12-31-01-02-03
+    --recover -o /sample-buildout/var/filestorage/bar.fs -r /sample-buildout/var/snapshotbackups_bar -D 1999-12-31-01-02-03
+    --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/snapshotbackups -D 1999-12-31-01-02-03
 
 The second blob file was only in blobstorage snapshot number 1 when we
 started and now it is also in the main blobstorage again.
@@ -570,50 +600,48 @@ Create some archived (gzipped) and not-archived separate backup scripts::
     Generated script '/sample-buildout/bin/snapshotrestore'.
     <BLANKLINE>
 
+Mock a repozo backup with timestamps.
+
+    >>> mkdir('var', 'zipbackups')
+    >>> write('var', 'zipbackups', '1999-12-31-03-01-01.fsz', 'mock datafs backup')
+
 Now we test it::
 
     >>> print(system('bin/zipbackup'))
-    INFO: Created /sample-buildout/var/zipbackups
     INFO: Created /sample-buildout/var/blobstoragezips
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/zipbackups
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragezips
-    INFO: tar cf /sample-buildout/var/blobstoragezips/blobstorage.20...-...-...-...-...-....tar  -C /sample-buildout/var/blobstorage .
-    INFO: Creating symlink from latest to blobstorage.20...-...-...-...-...-....tar
+    INFO: tar cf /sample-buildout/var/blobstoragezips/blobstorage.1999-12-31-03-01-01.tar  -C /sample-buildout/var/blobstorage .
+    INFO: Creating symlink from latest to blobstorage.1999-12-31-03-01-01.tar
     <BLANKLINE>
     >>> check_repozo_output()
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups -F --gzip
     >>> ls('var', 'blobstoragezips')
-    -  blobstorage.20...-...-...-...-...-....tar
+    -  blobstorage.1999-12-31-03-01-01.tar
     l  latest
-    >>> zip_timestamp0 = sorted(os.listdir('var/blobstoragezips'))[0]
     >>> print(os.path.realpath('var/blobstoragezips/latest'))
-    /sample-buildout/var/blobstoragezips/blobstorage.20...-...-...-...-...-....tar
-    >>> os.path.realpath('var/blobstoragezips/latest').endswith(zip_timestamp0)
-    True
+    /sample-buildout/var/blobstoragezips/blobstorage.1999-12-31-03-01-01.tar
 
 Keep is ignored by zipbackup, always using 1 as value.
 Pause a short time to avoid getting an error for overwriting the previous file::
 
     >>> time.sleep(1)
+    >>> write('var', 'zipbackups', '1999-12-31-03-02-01.fsz', 'mock datafs backup')
     >>> print(system('bin/zipbackup'))
     INFO: Please wait while backing up database file: /sample-buildout/var/filestorage/Data.fs to /sample-buildout/var/zipbackups
+    INFO: Removed 1 file(s) belonging to old backups, the latest 1 full backups have been kept.
     INFO: Please wait while backing up blobs from /sample-buildout/var/blobstorage to /sample-buildout/var/blobstoragezips
-    INFO: tar cf /sample-buildout/var/blobstoragezips/blobstorage.20...-...-...-...-...-....tar  -C /sample-buildout/var/blobstorage .
-    INFO: Creating symlink from latest to blobstorage.20...-...-...-...-...-....tar
-    INFO: Removed 1 full blob backup, with 1 file. The latest 1 backup has been kept.
+    INFO: tar cf /sample-buildout/var/blobstoragezips/blobstorage.1999-12-31-03-02-01.tar  -C /sample-buildout/var/blobstorage .
+    INFO: Creating symlink from latest to blobstorage.1999-12-31-03-02-01.tar
+    INFO: Removed 1 blob backup, all backups belonging to remaining filestorage backups have been kept.
     <BLANKLINE>
     >>> check_repozo_output()
     --backup -f /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups -F --gzip
     >>> ls('var', 'blobstoragezips')
-    -  blobstorage.20...-...-...-...-...-....tar
+    -  blobstorage.1999-12-31-03-02-01.tar
     l  latest
-    >>> zip_timestamp1 = sorted(os.listdir('var/blobstoragezips'))[0]
-    >>> zip_timestamp0 == zip_timestamp1
-    False
     >>> print(os.path.realpath('var/blobstoragezips/latest'))
-    /sample-buildout/var/blobstoragezips/blobstorage.20...-...-...-...-...-....tar
-    >>> os.path.realpath('var/blobstoragezips/latest').endswith(zip_timestamp1)
-    True
+    /sample-buildout/var/blobstoragezips/blobstorage.1999-12-31-03-02-01.tar
 
 Now test the ziprestore script::
 
@@ -627,8 +655,8 @@ Now test the ziprestore script::
     INFO: Please wait while restoring database file: /sample-buildout/var/zipbackups to /sample-buildout/var/filestorage/Data.fs
     INFO: Restoring blobs from /sample-buildout/var/blobstoragezips to /sample-buildout/var/blobstorage
     INFO: Removing /sample-buildout/var/blobstorage
-    INFO: Extracting /sample-buildout/var/blobstoragezips/blobstorage.20...-...-...-...-...-....tar to /sample-buildout/var/blobstorage
-    INFO: tar xf /sample-buildout/var/blobstoragezips/blobstorage.20...-...-...-...-...-....tar  -C /sample-buildout/var/blobstorage
+    INFO: Extracting /sample-buildout/var/blobstoragezips/blobstorage.1999-12-31-03-02-01.tar to /sample-buildout/var/blobstorage
+    INFO: tar xf /sample-buildout/var/blobstoragezips/blobstorage.1999-12-31-03-02-01.tar  -C /sample-buildout/var/blobstorage
     <BLANKLINE>
     >>> check_repozo_output()
     --recover -o /sample-buildout/var/filestorage/Data.fs -r /sample-buildout/var/zipbackups


### PR DESCRIPTION
A snapshot backup would erroneously use the timestamp from the normal backup.
Fixes issue #55.
