### PR TITLE
Added an option to use hard links for the first backup copy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -498,11 +498,12 @@ some system-wide directory like ``/var/zopebackups/instancename/`` and
     ``rsync_options = --no-l -k`` does the trick.
 
 ``rsync_hard_links_on_first_copy``
-    When using ``rsync`` to make the first backup of the blobs, create hard links
-    instead of copies of the blobs.
-    This is useful to save disk space but you need to pay attention
-    that changing the blobs in the source folder
-    will change the blobs in the backup.
+    When using ``rsync``, the blob files for the first backup are copied
+    and then subsequent backups make use of hard links from this initial
+    copy, to save time and disk space.
+    Enable this option to also use hard links for the initial copy to further reduce 
+    disk usage.
+    This is safe for ZODB blobs, since they are not modified in place.
     The ``blob_storage`` and the backup folder ``blobbackuplocation``
     have to be in the same partition for hard links to be possible.
 

--- a/README.rst
+++ b/README.rst
@@ -497,6 +497,15 @@ some system-wide directory like ``/var/zopebackups/instancename/`` and
     a backup from a symlinked directory, in which case
     ``rsync_options = --no-l -k`` does the trick.
 
+``rsync_hard_links_on_first_copy``
+    When using ``rsync`` to make the first backup of the blobs, create hard links
+    instead of copies of the blobs.
+    This is useful to save disk space but you need to pay attention
+    that changing the blobs in the source folder
+    will change the blobs in the backup.
+    The ``blob_storage`` and the backup folder ``blobbackuplocation``
+    have to be in the same partition for hard links to be possible.
+
 ``snapshotlocation``
     Location where snapshot backups of the filestorage are stored. Defaults to
     ``var/snapshotbackups`` inside the buildout directory.

--- a/news/57.feature
+++ b/news/57.feature
@@ -1,0 +1,3 @@
+Added an option to use hard links for the first backup copy
+[ale-rt]
+

--- a/src/collective/recipe/backup/__init__.py
+++ b/src/collective/recipe/backup/__init__.py
@@ -146,6 +146,7 @@ class Recipe:
         options.setdefault("quick", "true")
         options.setdefault("rsync_options", "")
         options.setdefault("use_rsync", "true")
+        options.setdefault("rsync_hard_links_on_first_copy", "false")
 
         # Get the blob storage.
         blob_storage = options["blob_storage"]
@@ -461,6 +462,7 @@ logging.basicConfig(level=loglevel,
         no_prompt=options.no_prompt,
         blob_timestamps={blob_timestamps},
         incremental_blobs={incremental_blobs},
+        rsync_hard_links_on_first_copy={rsync_hard_links_on_first_copy},
         """
         # Work with a copy of the options, for safety.
         opts = self.options.copy()
@@ -602,6 +604,7 @@ logging.basicConfig(level=loglevel,
                 "compress_blob",
                 "blob_timestamps",
                 "incremental_blobs",
+                "rsync_hard_links_on_first_copy",
             ],
         )
 

--- a/src/collective/recipe/backup/main.py
+++ b/src/collective/recipe/backup/main.py
@@ -32,6 +32,7 @@ def backup_main(
     blob_timestamps=False,
     backup_method=config.STANDARD_BACKUP,
     incremental_blobs=False,
+    rsync_hard_links_on_first_copy=False,
     **kwargs,
 ):
     """Main method, gets called by generated bin/backup."""
@@ -106,6 +107,7 @@ def backup_main(
             timestamps=blob_timestamps,
             fs_backup_location=fs_backup_location,
             incremental_blobs=incremental_blobs,
+            rsync_hard_links_on_first_copy=rsync_hard_links_on_first_copy,
         )
     utils.execute_or_fail(post_command)
 

--- a/src/collective/recipe/backup/tests/backup_blobs_dir_hard_links.rst
+++ b/src/collective/recipe/backup/tests/backup_blobs_dir_hard_links.rst
@@ -1,0 +1,256 @@
+# -*-doctest-*-
+
+Test the copyblobs.backup_blobs function with hard_links
+========================================================
+
+This especially tests backing up to directories with the option
+``rsync_hard_links_on_first_copy`` turned on.
+
+
+Import stuff.
+
+    >>> from collective.recipe.backup.copyblobs import backup_blobs
+    >>> from collective.recipe.backup.copyblobs import restore_blobs
+    >>> import os
+    >>> import time
+
+Prepare some blobs.
+
+    >>> mkdir('blobs')
+    >>> write('blobs', 'one.txt', 'File One')
+    >>> write('blobs', 'two.txt', 'File Two')
+    >>> write('blobs', 'three.txt', 'File Three')
+    >>> mkdir('blobs', 'dir')
+    >>> mkdir('backups')
+
+Do a backup.
+
+    >>> backup_blobs('blobs', 'backups', rsync_hard_links_on_first_copy=True)
+    >>> ls('backups')
+    d  blobs.0
+    >>> ls('backups', 'blobs.0')
+    d  blobs
+    >>> ls('backups', 'blobs.0', 'blobs')
+    d  dir
+    -  one.txt
+    -  three.txt
+    -  two.txt
+
+Check the file stats to see if they are really hard links:
+
+    >>> stat_0 = os.stat(os.path.join('blobs', 'three.txt'))
+    >>> stat_1 = os.stat(os.path.join('backups', 'blobs.0', 'blobs', 'three.txt'))
+    >>> stat_0.st_ino == stat_1.st_ino
+    True
+
+Change some stuff, note that given that the backup
+has hard links the files in the backup will be modified when the .
+
+    >>> write('blobs', 'one.txt', 'Changed File One')
+    >>> write('blobs', 'four.txt', 'File Four')
+    >>> remove('blobs', 'two.txt')
+    >>> backup_blobs('blobs/', 'backups', rsync_hard_links_on_first_copy=True)
+    >>> ls('backups')
+    d  blobs.0
+    d  blobs.1
+    >>> ls('backups', 'blobs.1', 'blobs')
+    d  dir
+    -  one.txt
+    -  three.txt
+    -  two.txt
+    >>> ls('backups', 'blobs.0', 'blobs')
+    d  dir
+    -  four.txt
+    -  one.txt
+    -  three.txt
+    >>> cat('backups', 'blobs.1', 'blobs', 'one.txt')
+    Changed File One
+    >>> cat('backups', 'blobs.0', 'blobs', 'one.txt')
+    Changed File One
+
+Check the file stats to see if they are really hard links:
+
+    >>> stat_0 = os.stat(os.path.join('blobs', 'three.txt'))
+    >>> stat_1 = os.stat(os.path.join('backups', 'blobs.0', 'blobs',
+    ...                               'three.txt'))
+    >>> stat_2 = os.stat(os.path.join('backups', 'blobs.1', 'blobs',
+    ...                               'three.txt'))
+    >>> stat_0.st_ino == stat_1.st_ino == stat_2.st_ino
+    True
+
+Now cleanup and try with filestamps.
+
+    >>> remove('backups')
+    >>> mkdir('backups')
+    >>> backup_blobs('blobs', 'backups', timestamps=True, rsync_hard_links_on_first_copy=True)
+    >>> ls('backups')
+    d  blobs.20...-...-...-...-...
+    >>> backup0 = sorted(os.listdir('backups'))[0]
+    >>> timestamp0 = backup0[len('blobs.'):]
+    >>> ls('backups', backup0, 'blobs')
+    d  dir
+    -  four.txt
+    -  one.txt
+    -  three.txt
+
+Wait a while, so we get a different timestamp, and then change some stuff.
+
+    >>> time.sleep(1)
+    >>> remove('blobs', 'three.txt')
+    >>> remove('blobs', 'four.txt')
+    >>> backup_blobs('blobs', 'backups', timestamps=True, rsync_hard_links_on_first_copy=True)
+    >>> ls('backups')
+    d  blobs.20...-...-...-...-...
+    d  blobs.20...-...-...-...-...
+    d  latest
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobs.20...-...-...-...-...
+    >>> backup1 = sorted(os.listdir('backups'))[1]
+    >>> timestamp1 = backup1[len('blobs.'):]
+    >>> timestamp0 < timestamp1
+    True
+    >>> ls('backups', backup1, 'blobs')
+    d  dir
+    -  one.txt
+
+Now we pretend that there is a filestorage backup from the time that
+the most recent backup was made.
+Pass that to the backup_blobs function.
+It should not make a new blob backup, because there is one matching
+the most recent filestorage backup.
+This actually cleans up the oldest backup, because it does not belong
+to any filestorage backup.
+
+    >>> mkdir('fs')
+    >>> write('fs', '{0}.fsz'.format(timestamp1), 'dummy fs' )
+    >>> backup_blobs('blobs', 'backups', timestamps=True,
+    ...     fs_backup_location='fs', rsync_hard_links_on_first_copy=True)
+    >>> ls('backups')
+    d  blobs.20...-...-...-...-...
+    d  latest
+    >>> len(sorted(os.listdir('backups')))  # The dots could shadow other backups.
+    2
+    >>> backup1 == sorted(os.listdir('backups'))[0]
+    True
+    >>> ls('backups', backup1, 'blobs')
+    d  dir
+    -  one.txt
+
+Pretend there is a newer filestorage backup and a blob change.
+
+    >>> write('blobs', 'two.txt', 'File two')
+    >>> write('fs', '2100-01-01-00-00-00.fsz', 'dummy fs')
+    >>> backup_blobs('blobs', 'backups', timestamps=True,
+    ...    fs_backup_location='fs', rsync_hard_links_on_first_copy=True)
+    >>> ls('backups')
+    d  blobs.20...-...-...-...-...
+    d  blobs.2100-01-01-00-00-00
+    d  latest
+    >>> len(sorted(os.listdir('backups')))  # The dots could shadow a third backup
+    3
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobs.2100-01-01-00-00-00
+    >>> ls('backups', 'blobs.2100-01-01-00-00-00', 'blobs')
+    d  dir
+    -  one.txt
+    -  two.txt
+
+Check a restore with archive=True.
+This should prefer archives, but should be able to restore non-archives too.
+
+    >>> ls('blobs')
+    d  dir
+    -  one.txt
+    -  two.txt
+    >>> restore_blobs('backups', os.path.abspath('blobs'), date='2099-01-01-00-00-00', archive_blob=True, timestamps=True)
+    >>> ls('blobs')
+    d  dir
+    -  one.txt
+
+Remove the oldest filestorage backup.
+
+    >>> remove('fs', '{0}.fsz'.format(timestamp1))
+    >>> backup_blobs('blobs', 'backups', timestamps=True,
+    ...    fs_backup_location='fs', rsync_hard_links_on_first_copy=True)
+    >>> ls('backups')
+    d  blobs.2100-01-01-00-00-00
+    d  latest
+    >>> len(sorted(os.listdir('backups')))
+    2
+    >>> print(os.path.realpath('backups/latest'))
+    /sample-buildout/backups/blobs.2100-01-01-00-00-00
+
+Cleanup:
+
+    >>> remove('blobs')
+    >>> remove('backups')
+
+We do mostly the same as above, but now using full backups.
+
+    >>> mkdir('blobs')
+    >>> write('blobs', 'one.txt', 'File One')
+    >>> write('blobs', 'two.txt', 'File Two')
+    >>> write('blobs', 'three.txt', 'File Three')
+    >>> mkdir('blobs', 'dir')
+    >>> mkdir('backups')
+    >>> backup_blobs('blobs', 'backups', full=True, rsync_hard_links_on_first_copy=True)
+    >>> ls('backups')
+    d  blobs.0
+    >>> ls('backups', 'blobs.0')
+    d  blobs
+    >>> ls('backups', 'blobs.0', 'blobs')
+    d  dir
+    -  one.txt
+    -  three.txt
+    -  two.txt
+
+Check the file stats to see if they are really hard links:
+
+    >>> stat_0 = os.stat(os.path.join('blobs', 'three.txt'))
+    >>> stat_1 = os.stat(os.path.join('backups', 'blobs.0', 'blobs', 'three.txt'))
+    >>> stat_0.st_ino == stat_1.st_ino
+    True
+
+Change some stuff.
+
+    >>> write('blobs', 'one.txt', 'Changed File One')
+    >>> write('blobs', 'four.txt', 'File Four')
+    >>> remove('blobs', 'two.txt')
+    >>> backup_blobs('blobs', 'backups', full=True, rsync_hard_links_on_first_copy=True)
+    >>> ls('backups')
+    d  blobs.0
+    d  blobs.1
+    >>> ls('backups', 'blobs.1', 'blobs')
+    d  dir
+    -  one.txt
+    -  three.txt
+    -  two.txt
+    >>> ls('backups', 'blobs.0', 'blobs')
+    d  dir
+    -  four.txt
+    -  one.txt
+    -  three.txt
+    >>> cat('backups', 'blobs.1', 'blobs', 'one.txt')
+    Changed File One
+    >>> cat('backups', 'blobs.0', 'blobs', 'one.txt')
+    Changed File One
+
+Check the file stats.  We did full copies, but these should still
+be hard links.
+
+    >>> stat_0 = os.stat(os.path.join('blobs', 'three.txt'))
+    >>> stat_1 = os.stat(os.path.join('backups', 'blobs.0', 'blobs', 'three.txt'))
+    >>> stat_2 = os.stat(os.path.join('backups', 'blobs.1', 'blobs', 'three.txt'))
+    >>> stat_0.st_ino == stat_1.st_ino == stat_2.st_ino
+    True
+
+    >>> backup_blobs('blobs', 'backups', timestamps=True, rsync_hard_links_on_first_copy=True)
+    >>> ls('backups')
+    d  blobs.0
+    d  blobs.1
+    d  blobs.20...
+
+Cleanup:
+
+    >>> remove('blobs')
+    >>> remove('backups')

--- a/src/collective/recipe/backup/tests/test_docs.py
+++ b/src/collective/recipe/backup/tests/test_docs.py
@@ -96,6 +96,7 @@ def test_suite():
         "altrestore.rst",
         "backup_blobs_archive.rst",
         "backup_blobs_dir.rst",
+        "backup_blobs_dir_hard_links.rst",
         "base.rst",
         "blobs.rst",
         "blob_timestamps.rst",


### PR DESCRIPTION
When using ``rsync`` to make the first backup of the blobs, create hard links instead of copies of the blobs.
This is useful to save disk space but you need to pay attention that changing the blobs in the source folder
will change the blobs in the backup.
The ``blob_storage`` and the backup folder ``blobbackuplocation`` have to be in the same partition for hard links to be possible.

Fixes #57