### PR TITLE
Removed option `gzip_blob`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -401,9 +401,6 @@ some system-wide directory like ``/var/zopebackups/instancename/`` and
     false, but it so totally makes sense to gzip your backups that we changed
     the default.
 
-``gzip_blob``
-    Backwards compatibility alias for ``archive_blob`` option.
-
 ``incremental_blobs``
     New in version 4.0.  Default is false.
     When switched on, it will use the ``--listed-incremental`` option of ``tar``.
@@ -501,7 +498,7 @@ some system-wide directory like ``/var/zopebackups/instancename/`` and
     When using ``rsync``, the blob files for the first backup are copied
     and then subsequent backups make use of hard links from this initial
     copy, to save time and disk space.
-    Enable this option to also use hard links for the initial copy to further reduce 
+    Enable this option to also use hard links for the initial copy to further reduce
     disk usage.
     This is safe for ZODB blobs, since they are not modified in place.
     The ``blob_storage`` and the backup folder ``blobbackuplocation``

--- a/news/68.breaking
+++ b/news/68.breaking
@@ -1,0 +1,5 @@
+Removed option ``gzip_blob``.
+This was a backwards compatibility alias for ``archive_blob``.
+You should use that now it you want to create a tar archive.
+Additionally use the ``compress_blob`` option if you are really sure you want to compress the archive.
+[maurits]

--- a/src/collective/recipe/backup/__init__.py
+++ b/src/collective/recipe/backup/__init__.py
@@ -127,8 +127,7 @@ class Recipe:
         # more options, alphabetical
         options.setdefault("additional_filestorages", "")
         options.setdefault("alternative_restore_sources", "")
-        # archive_blob used to be called gzip_blob.
-        options.setdefault("archive_blob", options.get("gzip_blob", "false"))
+        options.setdefault("archive_blob", "false")
         options.setdefault("blob_timestamps", "true")
         options.setdefault("compress_blob", "false")
         options.setdefault("datafs", datafs)


### PR DESCRIPTION
This was a backwards compatibility alias for `archive_blob`. You should use that now it you want to create a tar archive. Additionally use the `compress_blob` option if you are really sure you want to compress the archive.

Fixes https://github.com/collective/collective.recipe.backup/issues/68