### PR TITLE
Add lint and format tox environments.

### DIFF
--- a/docker_format.sh
+++ b/docker_format.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Work around tox limitation. Given this command:
+#   docker run --user="$(id -u $(whoami)):$(getent group $(whoami)|cut -d: -f3)" --rm -v "{toxinidir}":/github/workspace plone/code-quality:latest format
+# You get this error:
+#   docker: Error response from daemon: unable to find user $(id -u $(whoami)): no matching entries in passwd file.
+docker run --user="$(id -u $(whoami)):$(getent group $(whoami)|cut -d: -f3)" --rm -v "${PWD}":/github/workspace plone/code-quality:latest format

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 # If you add a Python version here, remember to update the gh-actions yaml file.
 envlist =
+    lint
     py{38,39,310,311}
 
 [testenv]
@@ -12,3 +13,17 @@ commands_pre =
     {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =
     {envbindir}/test {posargs:-cv}
+
+[testenv:lint]
+allowlist_externals = docker
+deps =
+commands_pre =
+commands =
+    docker run --rm -v "{toxinidir}":/github/workspace plone/code-quality:latest check
+
+[testenv:format]
+allowlist_externals = ./docker_format.sh
+deps =
+commands_pre =
+commands =
+    ./docker_format.sh


### PR DESCRIPTION
The lint environment is the local version of what we already do in gh-actions in code-analysis.yml. The format environment is the formatting variant of the same command. Not completely happy with this setup, but it works, and it is just a few lines of code.